### PR TITLE
Change MODE 2 to use QVGA_320x240_60Hz

### DIFF
--- a/video.ino
+++ b/video.ino
@@ -622,7 +622,7 @@ int change_mode(int mode) {
 				errVal = change_resolution(16, VGA_512x384_60Hz);
 				break;
 			case 2:
-				errVal = change_resolution(64, VGA_320x200_75Hz);
+				errVal = change_resolution(64, QVGA_320x240_60Hz);
 				break;
 			case 3:
 				errVal = change_resolution(16, VGA_640x480_60Hz);


### PR DESCRIPTION
Mode 2 doesn't work on any of the monitors in my house. :-)

On the Facebook group, I saw that Lennart Benschop commented a couple times that perhaps QVGA_320x240_60Hz would be compatible with more monitors. Here's one of his comments:

> I really like this mode to be replaced by the QVGA_320x240_60Hz mode. Like the others it will have a 4:3 aspect ratio and it will have a line timing similar to 640x480 60Hz, but with double-scanned lines. That should make it work on every VGA monitor under the sun. And it does support 64 colours and runs well with the sprite demos.

This PR does just that! With these changes, I'm able to run the sprite demos, although, I'm pretty new to the Agon Light, so I'm not sure what other implications this could have.