### PR TITLE
Update video.ino to allow full use of canvas for VDU 28 windows.

### DIFF
--- a/video.ino
+++ b/video.ino
@@ -1162,7 +1162,7 @@ void vdu_textViewport() {
 	int x2 = readByte_t() * fontW;	// Right
 	int y1 = readByte_t() * fontH;	// Top
 
-	if(x1 >= 0 && x2 < canvasW && y1 >= 0 && y2 < canvasH && x2 > x1 && y2 > y1) {
+	if(x1 >= 0 && x2 <= canvasW && y1 >= 0 && y2 <= canvasH && x2 > x1 && y2 > y1) {
 		textViewport = Rect(x1, y1, x2 - 1, y2 - 1);
 		useViewports = true;
 		if(activeCursor->X < x1 || activeCursor->X > x2 || activeCursor->Y < y1 || activeCursor->Y > y2) {


### PR DESCRIPTION
This allows the text window to use the last column and last row of the canvas. This is needed as the coordinates passed are x2-1 and y2-1. I have tried writing this the other way around (i.e. just pass x2 and y2 as-is), and the results were not good.