### PR TITLE
New modes, legacy mode support, double-buffering support

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -45,6 +45,8 @@
 #define VDP_RTC					0x87	// RTC
 #define VDP_KEYSTATE			0x88	// Keyboard repeat rate and LED status
 #define VDP_LOGICALCOORDS		0xC0	// Switch BBC Micro style logical coords on and off
+#define VDP_LEGACYMODES			0xC1	// Switch VDP 1.03 compatible modes on and off
+#define VDP_SWITCHBUFFER		0xC3	// Double buffering control
 #define VDP_TERMINALMODE		0xFF	// Switch to terminal mode
 
 // And the corresponding return packets


### PR DESCRIPTION
This PR comprises the following features:

- New screen modes
- Backwards compatible support for existing ("legacy") screen modes
- Support for double buffered screen modes

In order to faciliate the last two, additional VDU parameters have been created as extensions to the VDU 23,0 command. The rationale for this approach is that VDU 23,0 is used for manipulating the registers on the CRTC (on the BBC) and similar functions on the Agon Light VDP. Both of the extensions created could be seen from the perspective of setting registers in the VDP to provide the required functionality.

# New screen modes

These screen modes have been chosen as the resolutions and refresh rates that should be compatible with the majority (all?) VGA/SVGA monitors. This could be considered the "standard" set of screen modes. Some of the more non-standard, esoteric modes suggested by the community are not included in this PR as they require additional testing. 

The following screen modes are defined in the PR:

## VGA standard resolutions and refresh rates

| Mode | Details | FabGL Mode | Notes |
|---|---|---|---|
| 0 | 640x480 in 16 colours at 60Hz | VGA_640x480_60Hz | VDP 1.03 Mode 3, VGA Mode 12h |
| 1 | 640x480 in 4 colours at 60Hz | VGA_640x480_60Hz |
| 2 | 640x480 in 2 colours at 60Hz | VGA_640x480_60Hz |
| 3 | 640x240 in 64 colours at 60Hz | VGA_640x240_60Hz |
| 4 | 640x240 in 16 colours at 60Hz | VGA_640x240_60Hz |
| 5 | 640x240 in 4 colours at 60Hz | VGA_640x240_60Hz |
| 6 | 640x240 in 2 colours at 60Hz | VGA_640x240_60Hz |
| 7 | Invalid Mode | N/A | Reserved for Teletext Mode |
| 8 | 320x240 in 64 colours at 60Hz | QVGA_320x240_60Hz | VGA "Mode X" |
| 9 | 320x240 in 16 colours at 60Hz | QVGA_320x240_60Hz |
| 10 | 320x240 in 4 colours at 60Hz | QVGA_320x240_60Hz |
| 11 | 320x240 in 2 colours at 60Hz | QVGA_320x240_60Hz |
| 12 | 320x200 in 64 colours at 70Hz | VGA_320x200_70Hz | VGA Mode 13h |
| 13 | 320x200 in 16 colours at 70Hz | VGA_320x200_70Hz |
| 14 | 320x200 in 4 colours at 70Hz | VGA_320x200_70Hz |
| 15 | 320x200 in 2 colours at 70Hz | VGA_320x200_70Hz |

## SVGA resolutions and refresh rates

Additionally, beyond VGA, the following SVGA modes are included:

| Mode | Details | FabGL Mode | Notes |
|---|---|---|---|
| 16 | 800x600 in 4 colours at 60Hz | SVGA_800x600_60Hz |
| 17 | 800x600 in 2 colours at 60Hz | SVGA_800x600_60Hz |
| 18 | 1024x768 in 2 colours at 60Hz | SVGA_1024x768_60Hz | VDP 1.03 Mode 0 |

## Double Buffered Modes

The following modes implement double buffering. They are numbered as the non-buffered mode numbers + 128. This is similar to how "Shadow" modes were implemented on the BBC B+/Master. There is insufficient memory to support Modes 128 (640x480 in 16 colours) and 131 (640x240 in 64 colours) and these are therefore described as invalid modes in the table below.

| Mode | Details | FabGL Mode | Notes |
|---|---|---|---|
| 128 | Invalid Mode | N/A | Insufficient Memory |
| 129 | 640x480 in 4 colours at 60Hz | VGA_640x480_60Hz | Double buffered Mode 1 |
| 130 | 640x480 in 2 colours at 60Hz | VGA_640x480_60Hz | Double buffered Mode 2 |
| 131 | Invalid Mode | N/A | Insufficient Memory |
| 132 | 640x240 in 16 colours at 60Hz | VGA_640x240_60Hz | Double buffered Mode 4 |
| 133 | 640x240 in 4 colours at 60Hz | VGA_640x240_60Hz | Double buffered Mode 5 |
| 134 | 640x240 in 2 colours at 60Hz | VGA_640x240_60Hz | Double buffered Mode 6 |
| 135 | Invalid Mode | N/A | Reserved for Teletext Mode |
| 136 | 320x240 in 64 colours at 60Hz | QVGA_320x240_60Hz | Double buffered Mode 8 |
| 137 | 320x240 in 16 colours at 60Hz | QVGA_320x240_60Hz | Double buffered Mode 9 |
| 138 | 320x240 in 4 colours at 60Hz | QVGA_320x240_60Hz | Double buffered Mode 10 |
| 139 | 320x240 in 2 colours at 60Hz | QVGA_320x240_60Hz | Double buffered Mode 11 |
| 140 | 320x200 in 64 colours at 70Hz | VGA_320x200_70Hz | Double buffered Mode 12 |
| 141 | 320x200 in 16 colours at 70Hz | VGA_320x200_70Hz | Double buffered Mode 13 |
| 142 | 320x200 in 4 colours at 70Hz | VGA_320x200_70Hz | Double buffered Mode 14 |
| 143 | 320x200 in 2 colours at 70Hz | VGA_320x200_70Hz | Double buffered Mode 15 |

# Legacy screen mode support

The new screen modes are grouped together logically by resolution and then by decreasing number of colours. The current (VDP 1.03) modes are not structured in this way. In order to provide backwards compatibility for existing screen modes, following command has been added: VDU 23,0,193

This VDU command will set the VDP to support the modes listed above, or the original four modes defined in VDP 1.03. The options are:

- VDU 23,0,193,0 = Use "new" screen mode definitions (the default)
- VDU 23,0,193,1 = Use legacy screen modes as defined in VDP 1.03

Note: in the current implementation, running the MODE command after running the VDU command will only take effect if you are changing to a different numbered screen mode. For example, if you are in mode 0, make the VDU change and then try and set mode 0 again, it will not recognise the new mode. You must change to a different mode first.

# Support for double buffered screen modes

Selecting a double buffered screen mode will cause all writes to go to the back buffer and will therefore not be visible to the user. In order to display these writes, the screen buffers need to be swapped. In order to enable this, a new VDU command has been implemented: VDU 23,0,195

This allows the programmer to issue a set of drawing commands to the back buffer and then swap the buffers at the time of their choosing. 

[Side note: Why not VDU 23,0,194? This is currently being used in my VDP dev environment for other functionality that is not yet complete!]