### PR TITLE
Audio enhancements

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -70,7 +70,7 @@
 // Audio command definitions
 //
 #define AUDIO_CMD_PLAY			0		// Play a sound
-#define AUDIO_CMD_PLAYQUEUED	1		// Enhanced play with queue/synchronisation support
+#define AUDIO_CMD_PLAY_ADVANCED	1		// Enhanced play with additional parameters (TBD)
 #define AUDIO_CMD_WAVEFORM		2		// Set the waveform type for a channel
 #define AUDIO_CMD_SAMPLE		3		// Sample management
 #define AUDIO_CMD_VOLUME		4		// Set the volume of a channel
@@ -79,17 +79,20 @@
 #define AUDIO_CMD_ENV_FREQUENCY	7		// Define/set a frequency envelope
 #define AUDIO_CMD_STATUS		8		// Get the status of a channel
 #define AUDIO_CMD_RESET			9		// Reset audio channel/system
-#define AUDIO_WAVE_DEFAULT		1		// Default waveform (Square wave)
-#define AUDIO_WAVE_SAWTOOTH		0		// Sawtooth wave
-#define AUDIO_WAVE_SQUARE		1		// Square wave
-#define AUDIO_WAVE_SINE			2		// Sine wave
-#define AUDIO_WAVE_TRIANGLE		3		// Triangle wave
+#define AUDIO_WAVE_DEFAULT		0		// Default waveform (Square wave)
+#define AUDIO_WAVE_SQUARE		0		// Square wave
+#define AUDIO_WAVE_TRIANGLE		1		// Triangle wave
+#define AUDIO_WAVE_SAWTOOTH		2		// Sawtooth wave
+#define AUDIO_WAVE_SINE			3		// Sine wave
 #define AUDIO_WAVE_NOISE		4		// Noise (simple, no frequency support)
 #define AUDIO_WAVE_VICNOISE		5		// VIC-style noise (supports frequency)
 #define AUDIO_WAVE_SAMPLE		7		// Sample
 #define AUDIO_SAMPLE_LOAD		0		// Send a sample to the VDP
-#define AUDIO_SAMPLE_DUPLICATE	1		// Duplicate a sample
-#define AUDIO_SAMPLE_CLEAR		2		// Clear/delete a sample
+#define AUDIO_SAMPLE_CLEAR		1		// Clear/delete a sample
+#define AUDIO_SAMPLE_DUPLICATE	2		// Duplicate a sample
+#define AUDIO_ENVELOPE_NONE		0		// No envelope
+#define AUDIO_ENVELOPE_ADSR		1		// Simple ADSR volume envelope
+
 #define AUDIO_STATUS_PLAYING	0x00	// Channel is busy playing a note
 #define AUDIO_STATUS_SILENT		0x01	// Channel is silent
 #define AUDIO_STATUS_RELEASE	0x02	// Channel is available to play a new note but not completely silent

--- a/video/agon.h
+++ b/video/agon.h
@@ -93,10 +93,11 @@
 #define AUDIO_ENVELOPE_NONE		0		// No envelope
 #define AUDIO_ENVELOPE_ADSR		1		// Simple ADSR volume envelope
 
-#define AUDIO_STATUS_PLAYING	0x00	// Channel is busy playing a note
-#define AUDIO_STATUS_SILENT		0x01	// Channel is silent
-#define AUDIO_STATUS_RELEASE	0x02	// Channel is available to play a new note but not completely silent
-#define AUDIO_STATUS_ABORT		0x04	// Channel is aborting a note (temporary state)
+#define AUDIO_STATUS_ACTIVE		0x01	// Has an active waveform
+#define AUDIO_STATUS_PLAYING	0x02	// Playing a note (not in release phase)
+#define AUDIO_STATUS_INDEFINITE	0x04	// Indefinite duration sound playing
+#define AUDIO_STATUS_HAS_VOLUME_ENVELOPE	0x08	// Channel has a volume envelope set
+#define AUDIO_STATUS_HAS_FREQUENCY_ENVELOPE	0x10	// Channel has a frequency envelope set
 
 #define AUDIO_STATE_IDLE		0		// Channel is idle/silent
 #define AUDIO_STATE_PENDING		1		// Channel is pending (note will be played next loop call)

--- a/video/agon.h
+++ b/video/agon.h
@@ -71,17 +71,17 @@
 // Audio command definitions
 //
 #define AUDIO_CMD_PLAY			0		// Play a sound
-#define AUDIO_CMD_PLAY_ADVANCED	1		// Enhanced play with additional parameters (TBD)
-#define AUDIO_CMD_WAVEFORM		2		// Set the waveform type for a channel
-#define AUDIO_CMD_SAMPLE		3		// Sample management
-#define AUDIO_CMD_VOLUME		4		// Set the volume of a channel
-#define AUDIO_CMD_FREQUENCY		5		// Set the frequency of a channel
+#define AUDIO_CMD_STATUS		1		// Get the status of a channel
+#define AUDIO_CMD_VOLUME		2		// Set the volume of a channel
+#define AUDIO_CMD_FREQUENCY		3		// Set the frequency of a channel
+#define AUDIO_CMD_WAVEFORM		4		// Set the waveform type for a channel
+#define AUDIO_CMD_SAMPLE		5		// Sample management
 #define AUDIO_CMD_ENV_VOLUME	6		// Define/set a volume envelope
 #define AUDIO_CMD_ENV_FREQUENCY	7		// Define/set a frequency envelope
-#define AUDIO_CMD_STATUS		8		// Get the status of a channel
-#define AUDIO_CMD_ENABLE		9		// Enables a channel
-#define AUDIO_CMD_DISABLE		10		// Disables (destroys) a channel
-#define AUDIO_CMD_RESET			11		// Reset audio channel
+#define AUDIO_CMD_ENABLE		8		// Enables a channel
+#define AUDIO_CMD_DISABLE		9		// Disables (destroys) a channel
+#define AUDIO_CMD_RESET			10		// Reset audio channel
+
 #define AUDIO_WAVE_DEFAULT		0		// Default waveform (Square wave)
 #define AUDIO_WAVE_SQUARE		0		// Square wave
 #define AUDIO_WAVE_TRIANGLE		1		// Triangle wave
@@ -90,9 +90,11 @@
 #define AUDIO_WAVE_NOISE		4		// Noise (simple, no frequency support)
 #define AUDIO_WAVE_VICNOISE		5		// VIC-style noise (supports frequency)
 #define AUDIO_WAVE_SAMPLE		7		// Sample
+
 #define AUDIO_SAMPLE_LOAD		0		// Send a sample to the VDP
 #define AUDIO_SAMPLE_CLEAR		1		// Clear/delete a sample
 #define AUDIO_SAMPLE_DUPLICATE	2		// Duplicate a sample
+
 #define AUDIO_ENVELOPE_NONE		0		// No envelope
 #define AUDIO_ENVELOPE_ADSR		1		// Simple ADSR volume envelope
 

--- a/video/agon.h
+++ b/video/agon.h
@@ -87,6 +87,10 @@
 #define AUDIO_SAMPLE_LOAD       0		// Send a sample to the VDP
 #define AUDIO_SAMPLE_DUPLICATE  1		// Duplicate a sample
 #define AUDIO_SAMPLE_CLEAR      2		// Clear/delete a sample
+#define AUDIO_CHANNEL_ENABLE    0		// Enable a channel
+#define AUDIO_CHANNEL_DISABLE   1		// Disable a channel
+#define AUDIO_CHANNEL_VOLUME    2		// Set the volume of a channel
+#define AUDIO_CHANNEL_FREQUENCY 3		// Set the frequency of a channel
 
 #define LOGICAL_SCRW            1280    // As per the BBC Micro standard
 #define LOGICAL_SCRH            1024

--- a/video/agon.h
+++ b/video/agon.h
@@ -79,7 +79,7 @@
 #define AUDIO_CMD_ENV_FREQUENCY	7		// Define/set a frequency envelope
 #define AUDIO_CMD_STATUS		8		// Get the status of a channel
 #define AUDIO_CMD_RESET			9		// Reset audio channel/system
-#define AUDIO_WAVE_DEFAULT		2		// Default waveform (Sawtooth)
+#define AUDIO_WAVE_DEFAULT		1		// Default waveform (Square wave)
 #define AUDIO_WAVE_SAWTOOTH		0		// Sawtooth wave
 #define AUDIO_WAVE_SQUARE		1		// Square wave
 #define AUDIO_WAVE_SINE			2		// Sine wave

--- a/video/agon.h
+++ b/video/agon.h
@@ -66,6 +66,7 @@
 
 #define AUDIO_CHANNELS			3		// Default number of audio channels
 #define MAX_AUDIO_CHANNELS		32		// Maximum number of audio channels
+#define MAX_AUDIO_SAMPLES		128		// Maximum number of audio samples
 #define PLAY_SOUND_PRIORITY		3		// Sound driver task priority with 3 (configMAX_PRIORITIES - 1) being the highest, and 0 being the lowest
 
 // Audio command definitions
@@ -89,11 +90,10 @@
 #define AUDIO_WAVE_SINE			3		// Sine wave
 #define AUDIO_WAVE_NOISE		4		// Noise (simple, no frequency support)
 #define AUDIO_WAVE_VICNOISE		5		// VIC-style noise (supports frequency)
-#define AUDIO_WAVE_SAMPLE		7		// Sample
+#define AUDIO_WAVE_SAMPLE		8		// Sample - values 8+ give sample number plus 8
 
 #define AUDIO_SAMPLE_LOAD		0		// Send a sample to the VDP
 #define AUDIO_SAMPLE_CLEAR		1		// Clear/delete a sample
-#define AUDIO_SAMPLE_DUPLICATE	2		// Duplicate a sample
 
 #define AUDIO_ENVELOPE_NONE		0		// No envelope
 #define AUDIO_ENVELOPE_ADSR		1		// Simple ADSR volume envelope

--- a/video/agon.h
+++ b/video/agon.h
@@ -64,7 +64,8 @@
 #define PACKET_RTC				0x07	// RTC
 #define PACKET_KEYSTATE			0x08	// Keyboard repeat rate and LED status
 
-#define AUDIO_CHANNELS			3		// Number of audio channels
+#define AUDIO_CHANNELS			3		// Default number of audio channels
+#define MAX_AUDIO_CHANNELS		32		// Maximum number of audio channels
 #define PLAY_SOUND_PRIORITY		3		// Sound driver task priority with 3 (configMAX_PRIORITIES - 1) being the highest, and 0 being the lowest
 
 // Audio command definitions
@@ -78,7 +79,8 @@
 #define AUDIO_CMD_ENV_VOLUME	6		// Define/set a volume envelope
 #define AUDIO_CMD_ENV_FREQUENCY	7		// Define/set a frequency envelope
 #define AUDIO_CMD_STATUS		8		// Get the status of a channel
-#define AUDIO_CMD_RESET			9		// Reset audio channel/system
+#define AUDIO_CMD_CONFIGURE		9		// Configure the audio system
+#define AUDIO_CMD_RESET			10		// Reset audio channel/system
 #define AUDIO_WAVE_DEFAULT		0		// Default waveform (Square wave)
 #define AUDIO_WAVE_SQUARE		0		// Square wave
 #define AUDIO_WAVE_TRIANGLE		1		// Triangle wave

--- a/video/agon.h
+++ b/video/agon.h
@@ -90,6 +90,7 @@
 #define AUDIO_WAVE_SINE			3		// Sine wave
 #define AUDIO_WAVE_NOISE		4		// Noise (simple, no frequency support)
 #define AUDIO_WAVE_VICNOISE		5		// VIC-style noise (supports frequency)
+#define AUDIO_WAVE_SAMPLE		8		// Sample playback (internally used, can't be passed as a parameter)
 // negative values for waveforms indicate a sample number
 
 #define AUDIO_SAMPLE_LOAD		0		// Send a sample to the VDP

--- a/video/agon.h
+++ b/video/agon.h
@@ -27,8 +27,8 @@
 #define UART_NA					-1
 #define UART_TX					2
 #define UART_RX					34
-#define UART_RTS  	 		 	13 		// The ESP32 RTS pin (eZ80 CTS)
-#define UART_CTS  	  			14		// The ESP32 CTS pin (eZ80 RTS)
+#define UART_RTS				13		// The ESP32 RTS pin (eZ80 CTS)
+#define UART_CTS	 			14		// The ESP32 CTS pin (eZ80 RTS)
 
 #define UART_RX_SIZE			256		// The RX buffer size
 #define UART_RX_THRESH			128		// Point at which RTS is toggled
@@ -65,32 +65,35 @@
 #define PACKET_KEYSTATE			0x08	// Keyboard repeat rate and LED status
 
 #define AUDIO_CHANNELS			3		// Number of audio channels
-#define PLAY_SOUND_PRIORITY 	3		// Sound driver task priority with 3 (configMAX_PRIORITIES - 1) being the highest, and 0 being the lowest
+#define PLAY_SOUND_PRIORITY		3		// Sound driver task priority with 3 (configMAX_PRIORITIES - 1) being the highest, and 0 being the lowest
 
 // Audio command definitions
 //
-#define AUDIO_CMD_PLAY          0		// Play a sound
-#define AUDIO_CMD_PLAYQUEUED    1		// Enhanced play with queue/synchronisation support
-#define AUDIO_CMD_WAVEFORM      2		// Set the waveform type for a channel
-#define AUDIO_CMD_SAMPLE        3		// Sample management
-#define AUDIO_CMD_ENV_VOLUME    4		// Define/set a volume envelope
-#define AUDIO_CMD_ENV_FREQUENCY 5		// Define/set a frequency envelope
-#define AUDIO_CMD_RESET         7		// Reset audio channel/system
-#define AUDIO_WAVE_DEFAULT      0		// Default waveform (Sawtooth)
-#define AUDIO_WAVE_SAWTOOTH     0		// Sawtooth wave
-#define AUDIO_WAVE_SQUARE       1		// Square wave
-#define AUDIO_WAVE_SINE         2		// Sine wave
-#define AUDIO_WAVE_TRIANGLE     3		// Triangle wave
-#define AUDIO_WAVE_NOISE        4		// Noise (simple, no frequency support)
-#define AUDIO_WAVE_VICNOISE     5		// VIC-style noise (supports frequency)
-#define AUDIO_WAVE_SAMPLE       7		// Sample
-#define AUDIO_SAMPLE_LOAD       0		// Send a sample to the VDP
-#define AUDIO_SAMPLE_DUPLICATE  1		// Duplicate a sample
-#define AUDIO_SAMPLE_CLEAR      2		// Clear/delete a sample
-#define AUDIO_CHANNEL_ENABLE    0		// Enable a channel
-#define AUDIO_CHANNEL_DISABLE   1		// Disable a channel
-#define AUDIO_CHANNEL_VOLUME    2		// Set the volume of a channel
-#define AUDIO_CHANNEL_FREQUENCY 3		// Set the frequency of a channel
+#define AUDIO_CMD_PLAY			0		// Play a sound
+#define AUDIO_CMD_PLAYQUEUED	1		// Enhanced play with queue/synchronisation support
+#define AUDIO_CMD_WAVEFORM		2		// Set the waveform type for a channel
+#define AUDIO_CMD_SAMPLE		3		// Sample management
+#define AUDIO_CMD_VOLUME		4		// Set the volume of a channel
+#define AUDIO_CMD_FREQUENCY		5		// Set the frequency of a channel
+#define AUDIO_CMD_ENV_VOLUME	6		// Define/set a volume envelope
+#define AUDIO_CMD_ENV_FREQUENCY	7		// Define/set a frequency envelope
+#define AUDIO_CMD_STATUS		8		// Get the status of a channel
+#define AUDIO_CMD_RESET			9		// Reset audio channel/system
+#define AUDIO_WAVE_DEFAULT		0		// Default waveform (Sawtooth)
+#define AUDIO_WAVE_SAWTOOTH		0		// Sawtooth wave
+#define AUDIO_WAVE_SQUARE		1		// Square wave
+#define AUDIO_WAVE_SINE			2		// Sine wave
+#define AUDIO_WAVE_TRIANGLE		3		// Triangle wave
+#define AUDIO_WAVE_NOISE		4		// Noise (simple, no frequency support)
+#define AUDIO_WAVE_VICNOISE		5		// VIC-style noise (supports frequency)
+#define AUDIO_WAVE_SAMPLE		7		// Sample
+#define AUDIO_SAMPLE_LOAD		0		// Send a sample to the VDP
+#define AUDIO_SAMPLE_DUPLICATE	1		// Duplicate a sample
+#define AUDIO_SAMPLE_CLEAR		2		// Clear/delete a sample
+#define AUDIO_STATUS_PLAYING	0x00	// Channel is busy playing a note
+#define AUDIO_STATUS_SILENT		0x01	// Channel is silent
+#define AUDIO_STATUS_RELEASE	0x02	// Channel is available to play a new note but not completely silent
+#define AUDIO_STATUS_ABORT		0x04	// Channel is aborting a note (temporary state)
 
 #define LOGICAL_SCRW            1280    // As per the BBC Micro standard
 #define LOGICAL_SCRH            1024

--- a/video/agon.h
+++ b/video/agon.h
@@ -79,8 +79,9 @@
 #define AUDIO_CMD_ENV_VOLUME	6		// Define/set a volume envelope
 #define AUDIO_CMD_ENV_FREQUENCY	7		// Define/set a frequency envelope
 #define AUDIO_CMD_STATUS		8		// Get the status of a channel
-#define AUDIO_CMD_CONFIGURE		9		// Configure the audio system
-#define AUDIO_CMD_RESET			10		// Reset audio channel/system
+#define AUDIO_CMD_ENABLE		9		// Enables a channel
+#define AUDIO_CMD_DISABLE		10		// Disables (destroys) a channel
+#define AUDIO_CMD_RESET			11		// Reset audio channel
 #define AUDIO_WAVE_DEFAULT		0		// Default waveform (Square wave)
 #define AUDIO_WAVE_SQUARE		0		// Square wave
 #define AUDIO_WAVE_TRIANGLE		1		// Triangle wave

--- a/video/agon.h
+++ b/video/agon.h
@@ -94,6 +94,7 @@
 
 #define AUDIO_SAMPLE_LOAD		0		// Send a sample to the VDP
 #define AUDIO_SAMPLE_CLEAR		1		// Clear/delete a sample
+#define AUDIO_SAMPLE_DEBUG_INFO 2		// Get debug info about a sample
 
 #define AUDIO_ENVELOPE_NONE		0		// No envelope
 #define AUDIO_ENVELOPE_ADSR		1		// Simple ADSR volume envelope

--- a/video/agon.h
+++ b/video/agon.h
@@ -42,7 +42,7 @@
 #define VDP_CURSOR				0x82	// Cursor positions
 #define VDP_SCRCHAR				0x83	// Character read from screen
 #define VDP_SCRPIXEL			0x84	// Pixel read from screen
-#define VDP_AUDIO				0x85	// Audio acknowledgement
+#define VDP_AUDIO				0x85	// Audio commands
 #define VDP_MODE				0x86	// Get screen dimensions
 #define VDP_RTC					0x87	// RTC
 #define VDP_KEYSTATE			0x88	// Keyboard repeat rate and LED status
@@ -66,6 +66,27 @@
 
 #define AUDIO_CHANNELS			3		// Number of audio channels
 #define PLAY_SOUND_PRIORITY 	3		// Sound driver task priority with 3 (configMAX_PRIORITIES - 1) being the highest, and 0 being the lowest
+
+// Audio command definitions
+//
+#define AUDIO_CMD_PLAY          0		// Play a sound
+#define AUDIO_CMD_PLAYQUEUED    1		// Enhanced play with queue/synchronisation support
+#define AUDIO_CMD_WAVEFORM      2		// Set the waveform type for a channel
+#define AUDIO_CMD_SAMPLE        3		// Sample management
+#define AUDIO_CMD_ENV_VOLUME    4		// Define/set a volume envelope
+#define AUDIO_CMD_ENV_FREQUENCY 5		// Define/set a frequency envelope
+#define AUDIO_CMD_RESET         7		// Reset audio channel/system
+#define AUDIO_WAVE_SAWTOOTH     0		// Sawtooth wave
+#define AUDIO_WAVE_SQUARE       1		// Square wave
+#define AUDIO_WAVE_SINE         2		// Sine wave
+#define AUDIO_WAVE_TRIANGLE     3		// Triangle wave
+#define AUDIO_WAVE_NOISE        4		// Noise (simple, no frequency support)
+#define AUDIO_WAVE_VICNOISE     5		// VIC-style noise (supports frequency)
+#define AUDIO_WAVE_SILENCE      6		// Silence
+#define AUDIO_WAVE_SAMPLE       7		// Sample
+#define AUDIO_SAMPLE_LOAD       0		// Send a sample to the VDP
+#define AUDIO_SAMPLE_DUPLICATE  1		// Duplicate a sample
+#define AUDIO_SAMPLE_CLEAR      2		// Clear/delete a sample
 
 #define LOGICAL_SCRW            1280    // As per the BBC Micro standard
 #define LOGICAL_SCRH            1024

--- a/video/agon.h
+++ b/video/agon.h
@@ -79,7 +79,7 @@
 #define AUDIO_CMD_ENV_FREQUENCY	7		// Define/set a frequency envelope
 #define AUDIO_CMD_STATUS		8		// Get the status of a channel
 #define AUDIO_CMD_RESET			9		// Reset audio channel/system
-#define AUDIO_WAVE_DEFAULT		0		// Default waveform (Sawtooth)
+#define AUDIO_WAVE_DEFAULT		2		// Default waveform (Sawtooth)
 #define AUDIO_WAVE_SAWTOOTH		0		// Sawtooth wave
 #define AUDIO_WAVE_SQUARE		1		// Square wave
 #define AUDIO_WAVE_SINE			2		// Sine wave
@@ -94,6 +94,13 @@
 #define AUDIO_STATUS_SILENT		0x01	// Channel is silent
 #define AUDIO_STATUS_RELEASE	0x02	// Channel is available to play a new note but not completely silent
 #define AUDIO_STATUS_ABORT		0x04	// Channel is aborting a note (temporary state)
+
+#define AUDIO_STATE_IDLE		0		// Channel is idle/silent
+#define AUDIO_STATE_PENDING		1		// Channel is pending (note will be played next loop call)
+#define AUDIO_STATE_PLAYING		2		// Channel is playing a note (passive)
+#define AUDIO_STATE_PLAY_LOOP	3		// Channel is in active note playing loop
+#define AUDIO_STATE_RELEASE		4		// Channel is releasing a note
+#define AUDIO_STATE_ABORT		5		// Channel is aborting a note
 
 #define LOGICAL_SCRW            1280    // As per the BBC Micro standard
 #define LOGICAL_SCRH            1024

--- a/video/agon.h
+++ b/video/agon.h
@@ -90,7 +90,7 @@
 #define AUDIO_WAVE_SINE			3		// Sine wave
 #define AUDIO_WAVE_NOISE		4		// Noise (simple, no frequency support)
 #define AUDIO_WAVE_VICNOISE		5		// VIC-style noise (supports frequency)
-#define AUDIO_WAVE_SAMPLE		8		// Sample - values 8+ give sample number plus 8
+// negative values for waveforms indicate a sample number
 
 #define AUDIO_SAMPLE_LOAD		0		// Send a sample to the VDP
 #define AUDIO_SAMPLE_CLEAR		1		// Clear/delete a sample

--- a/video/agon.h
+++ b/video/agon.h
@@ -76,13 +76,13 @@
 #define AUDIO_CMD_ENV_VOLUME    4		// Define/set a volume envelope
 #define AUDIO_CMD_ENV_FREQUENCY 5		// Define/set a frequency envelope
 #define AUDIO_CMD_RESET         7		// Reset audio channel/system
+#define AUDIO_WAVE_DEFAULT      0		// Default waveform (Sawtooth)
 #define AUDIO_WAVE_SAWTOOTH     0		// Sawtooth wave
 #define AUDIO_WAVE_SQUARE       1		// Square wave
 #define AUDIO_WAVE_SINE         2		// Sine wave
 #define AUDIO_WAVE_TRIANGLE     3		// Triangle wave
 #define AUDIO_WAVE_NOISE        4		// Noise (simple, no frequency support)
 #define AUDIO_WAVE_VICNOISE     5		// VIC-style noise (supports frequency)
-#define AUDIO_WAVE_SILENCE      6		// Silence
 #define AUDIO_WAVE_SAMPLE       7		// Sample
 #define AUDIO_SAMPLE_LOAD       0		// Send a sample to the VDP
 #define AUDIO_SAMPLE_DUPLICATE  1		// Duplicate a sample

--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -205,6 +205,9 @@ void audio_channel::setFrequency(word frequency) {
 }
 
 void audio_channel::setVolumeEnvelope(VolumeEnvelope * envelope) {
+	if (this->_volumeEnvelope != NULL) {
+		delete this->_volumeEnvelope;
+	}
 	this->_volumeEnvelope = envelope;
 	if (envelope != NULL && this->_state == AUDIO_STATE_PLAYING) {
 		// swap to looping

--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -13,6 +13,12 @@
 
 extern void audioTaskAbortDelay(int channel);
 
+struct audio_sample {
+	bool written = false;			// has sample been written?
+	int length = 0;					// Length of the sample in bytes
+	int8_t * data = NULL;			// Pointer to the sample data
+};
+
 // The audio channel class
 //
 class audio_channel {	

--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -28,6 +28,7 @@ class audio_channel {
 		void	setFrequency(word frequency);
 		void	setVolumeEnvelope(VolumeEnvelope * envelope);
 		void	loop();
+		byte	channel() { return _channel; }
 	private:
 		void	waitForAbort();
 		byte	getVolume(word elapsed);
@@ -46,11 +47,26 @@ class audio_channel {
 };
 
 struct audio_sample {
-	bool written = false;			// has sample been written?
+	~audio_sample();
 	int length = 0;					// Length of the sample in bytes
 	int8_t * data = nullptr;		// Pointer to the sample data
 	std::vector<std::shared_ptr<audio_channel>> channels;	// List of channels playing this sample
 };
+
+audio_sample::~audio_sample() {
+	// iterate over channels
+	for (auto channel : this->channels) {
+		debug_log("audio_sample: removing sample from channel %d\n\r", channel->channel());
+		// Remove sample from channel
+		channel->setWaveform(AUDIO_WAVE_DEFAULT);
+	}
+
+	if (this->data) {
+		free(this->data);
+	}
+
+	debug_log("audio_sample cleared\n\r");
+}
 
 audio_channel::audio_channel(int channel) {
 	this->_channel = channel;

--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -150,7 +150,6 @@ void audio_channel::setWaveform(byte waveformType) {
 		}
 		_waveform = newWaveform;
 		_waveformType = waveformType;
-		debug_log("audio_driver: attaching new waveform\n\r");
 		SoundGenerator.attach(_waveform);
 		debug_log("audio_driver: setWaveform %d done\n\r", waveformType);
 	}

--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -23,6 +23,7 @@ class audio_channel {
 		void	setWaveform(byte waveformType);
 		void	setVolume(byte volume);
 		void	setFrequency(word frequency);
+		void	setVolumeEnvelope(VolumeEnvelope * envelope);
 		void	loop();
 	private:
 		void	waitForAbort();
@@ -50,7 +51,6 @@ audio_channel::audio_channel(int channel) {
 	this->_waveform = NULL;
 	setWaveform(AUDIO_WAVE_DEFAULT);
 	this->_volumeEnvelope = NULL;
-	// this->_volumeEnvelope = new ADSRVolumeEnvelope(500, 60, 80, 300);
 	debug_log("audio_driver: init %d\n\r", this->_channel);
 }
 
@@ -182,6 +182,10 @@ void audio_channel::setFrequency(word frequency) {
 				this->_waveform->setFrequency(frequency);
 		}
 	}
+}
+
+void audio_channel::setVolumeEnvelope(VolumeEnvelope * envelope) {
+	this->_volumeEnvelope = envelope;
 }
 
 void audio_channel::waitForAbort() {

--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -27,7 +27,7 @@ class audio_channel {
 		void	setWaveform(int8_t waveformType, std::shared_ptr<audio_channel> channelRef);
 		void	setVolume(byte volume);
 		void	setFrequency(word frequency);
-		void	setVolumeEnvelope(VolumeEnvelope * envelope);
+		void	setVolumeEnvelope(std::shared_ptr<VolumeEnvelope> envelope);
 		void	loop();
 		byte	channel() { return _channel; }
 	private:
@@ -44,7 +44,7 @@ class audio_channel {
 		word _frequency;
 		long _duration;
 		long _startTime;
-		std::unique_ptr<VolumeEnvelope> _volumeEnvelope;
+		std::shared_ptr<VolumeEnvelope> _volumeEnvelope;
 };
 
 struct audio_sample {
@@ -314,8 +314,8 @@ void audio_channel::setFrequency(word frequency) {
 	}
 }
 
-void audio_channel::setVolumeEnvelope(VolumeEnvelope * envelope) {
-	this->_volumeEnvelope.reset(envelope);
+void audio_channel::setVolumeEnvelope(std::shared_ptr<VolumeEnvelope> envelope) {
+	this->_volumeEnvelope = envelope;
 	if (envelope != nullptr && this->_state == AUDIO_STATE_PLAYING) {
 		// swap to looping
 		this->_state = AUDIO_STATE_PLAY_LOOP;

--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -18,6 +18,7 @@ extern void audioTaskAbortDelay(int channel);
 class audio_channel {	
 	public:
 		audio_channel(int channel);
+		~audio_channel();
 		word	play_note(byte volume, word frequency, word duration);
 		byte	getStatus();
 		void	setWaveform(byte waveformType);
@@ -52,6 +53,18 @@ audio_channel::audio_channel(int channel) {
 	setWaveform(AUDIO_WAVE_DEFAULT);
 	this->_volumeEnvelope = NULL;
 	debug_log("audio_driver: init %d\n\r", this->_channel);
+}
+
+audio_channel::~audio_channel() {
+	if (this->_waveform != NULL) {
+		this->_waveform->enable(false);
+		SoundGenerator.detach(this->_waveform);
+		delete this->_waveform;
+	}
+	if (this->_volumeEnvelope != NULL) {
+		delete this->_volumeEnvelope;
+	}
+	debug_log("audio_driver: deinit %d\n\r", this->_channel);
 }
 
 word audio_channel::play_note(byte volume, word frequency, word duration) {

--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -31,6 +31,7 @@ class audio_channel {
 audio_channel::audio_channel(int channel) {
 	this->_channel = channel;
 	this->_flag = 0;
+	this->_waveform = NULL;
 	setWaveform(AUDIO_WAVE_DEFAULT);
 	debug_log("audio_driver: init %d\n\r", this->_channel);			
 }
@@ -79,13 +80,18 @@ void audio_channel::setWaveform(byte waveformType) {
 		// TODO: abort any current playback in progress
 		// this will be needed when we support more sophsticated features like envelopes
 		if (this->_flag > 0) {
+			debug_log("audio_driver: aborting current playback\n\r");
 			// playback is happening, so abort any current task delay to allow playback to end
 			audioTaskAbortDelay(this->_channel);
 		}
-		SoundGenerator.detach(_waveform);
-		delete _waveform;
+		if(_waveform != NULL) {
+			debug_log("audio_driver: detaching old waveform\n\r");
+			SoundGenerator.detach(_waveform);
+			delete _waveform;
+		}
 		_waveform = newWaveform;
 		_waveformType = waveformType;
+		debug_log("audio_driver: attaching new waveform\n\r");
 		SoundGenerator.attach(_waveform);
 		debug_log("audio_driver: setWaveform %d done\n\r", waveformType);
 	}

--- a/video/envelopes.h
+++ b/video/envelopes.h
@@ -4,8 +4,6 @@
 // Created:       	06/08/2023
 // Last Updated:	06/08/2023
 
-#include <Arduino.h>
-
 class VolumeEnvelope {
 	public:
 		virtual byte getVolume(byte baseVolume, word elapsed, long duration);

--- a/video/envelopes.h
+++ b/video/envelopes.h
@@ -1,0 +1,81 @@
+//
+// Title:	        Audio Envelope support
+// Author:        	Steve Sims
+// Created:       	06/08/2023
+// Last Updated:	06/08/2023
+
+#include <Arduino.h>
+
+class VolumeEnvelope {
+	public:
+		virtual byte getVolume(byte baseVolume, word elapsed, long duration);
+		virtual bool isReleasing(word elapsed, long duration);
+		virtual bool isFinished(word elapsed, long duration);
+};
+
+class ADSRVolumeEnvelope : public VolumeEnvelope {
+	public:
+		ADSRVolumeEnvelope(word attack, word decay, byte sustain, word release);
+		byte getVolume(byte baseVolume, word elapsed, long duration);
+		bool isReleasing(word elapsed, long duration);
+		bool isFinished(word elapsed, long duration);
+	private:
+		word _attack;
+		word _decay;
+		byte _sustain;
+		word _release;
+};
+
+ADSRVolumeEnvelope::ADSRVolumeEnvelope(word attack, word decay, byte sustain, word release) {
+	// attack, decay, release are time values in milliseconds
+	// sustain is 0-255, centered on 127, and is the relative sustain level
+	this->_attack = attack;
+	this->_decay = decay;
+	this->_sustain = sustain;
+	this->_release = release;
+	debug_log("audio_driver: ADSRVolumeEnvelope: attack=%d, decay=%d, sustain=%d, release=%d\n\r", this->_attack, this->_decay, this->_sustain, this->_release);
+}
+
+byte ADSRVolumeEnvelope::getVolume(byte baseVolume, word elapsed, long duration) {
+	// returns volume for the given elapsed time
+	// baseVolume is the level the attack phase should reach
+	// sustain volume level is calculated relative to baseVolume
+	// volume for fab-gl is 0-127 but accepts higher values, so we're not clamping
+	// a duration of -1 means we're playing forever
+	long phaseTime = elapsed;
+	if (phaseTime < this->_attack) {
+		return (phaseTime * baseVolume) / this->_attack;
+	}
+	phaseTime -= this->_attack;
+	byte sustainVolume = baseVolume * this->_sustain / 127;
+	if (phaseTime < this->_decay) {
+		return map(phaseTime, 0, this->_decay, baseVolume, sustainVolume);
+	}
+	phaseTime -= this->_decay;
+	long sustainDuration = duration < 0 ? elapsed : duration - (this->_attack + this->_decay);
+	if (sustainDuration < 0) sustainDuration = 0;
+	if (phaseTime < sustainDuration) {
+		return sustainVolume;
+	}
+	phaseTime -= sustainDuration;
+	if (phaseTime < this->_release) {
+		return map(phaseTime, 0, this->_release, sustainVolume, 0);
+	}
+	return 0;
+}
+
+bool ADSRVolumeEnvelope::isReleasing(word elapsed, long duration) {
+	if (duration < 0) return false;
+	word minDuration = this->_attack + this->_decay;
+	if (duration < minDuration) duration = minDuration;
+
+	return (elapsed >= duration);
+}
+
+bool ADSRVolumeEnvelope::isFinished(word elapsed, long duration) {
+	if (duration < 0) return false;
+	word minDuration = this->_attack + this->_decay;
+	if (duration < minDuration) duration = minDuration;
+
+	return (elapsed >= duration + this->_release);
+}

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -94,12 +94,13 @@ word play_note(byte channel, byte volume, word frequency, word duration) {
 	return 1;
 }
 
-// Set channel waveform
+// Get channel status
 //
-void setWaveform(byte channel, byte waveformType) {
+byte getChannelStatus(byte channel) {
 	if (channelEnabled(channel)) {
-		audio_channels[channel]->setWaveform(waveformType);
+		return audio_channels[channel]->getStatus();
 	}
+	return -1;
 }
 
 // Set channel volume
@@ -115,6 +116,14 @@ void setVolume(byte channel, byte volume) {
 void setFrequency(byte channel, word frequency) {
 	if (channelEnabled(channel)) {
 		audio_channels[channel]->setFrequency(frequency);
+	}
+}
+
+// Set channel waveform
+//
+void setWaveform(byte channel, byte waveformType) {
+	if (channelEnabled(channel)) {
+		audio_channels[channel]->setWaveform(waveformType);
 	}
 }
 
@@ -138,15 +147,6 @@ void setVolumeEnvelope(byte channel, byte type) {
 	}
 }
 
-// Get channel status
-//
-byte getChannelStatus(byte channel) {
-	if (channelEnabled(channel)) {
-		return audio_channels[channel]->getStatus();
-	}
-	return -1;
-}
-
 // Audio VDU command support (VDU 23, 0, &85, <args>)
 //
 void vdu_sys_audio() {
@@ -161,19 +161,9 @@ void vdu_sys_audio() {
 
 			sendAudioStatus(channel, play_note(channel, volume, frequency, duration));
 		}	break;
-	
-		case AUDIO_CMD_PLAY_ADVANCED: {
-			debug_log("vdu_sys_audio: play_advanced - not implemented yet\n\r");
-		} 	break;
 
-		case AUDIO_CMD_WAVEFORM: {
-			int waveform = readByte_t();	if (waveform == -1) return;
-
-			setWaveform(channel, waveform);
-		}	break;
-
-		case AUDIO_CMD_SAMPLE: {
-			debug_log("vdu_sys_audio: sample - not implemented yet\n\r");
+		case AUDIO_CMD_STATUS: {
+			sendAudioStatus(channel, getChannelStatus(channel));
 		}	break;
 
 		case AUDIO_CMD_VOLUME: {
@@ -188,6 +178,16 @@ void vdu_sys_audio() {
 			setFrequency(channel, frequency);
 		}	break;
 
+		case AUDIO_CMD_WAVEFORM: {
+			int waveform = readByte_t();	if (waveform == -1) return;
+
+			setWaveform(channel, waveform);
+		}	break;
+
+		case AUDIO_CMD_SAMPLE: {
+			debug_log("vdu_sys_audio: sample - not implemented yet\n\r");
+		}	break;
+
 		case AUDIO_CMD_ENV_VOLUME: {
 			int type = readByte_t();		if (type == -1) return;
 
@@ -196,10 +196,6 @@ void vdu_sys_audio() {
 
 		case AUDIO_CMD_ENV_FREQUENCY: {
 			debug_log("vdu_sys_audio: env_frequency - not implemented yet\n\r");
-		}	break;
-
-		case AUDIO_CMD_STATUS: {
-			sendAudioStatus(channel, getChannelStatus(channel));
 		}	break;
 
 		case AUDIO_CMD_ENABLE: {

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -17,6 +17,8 @@ extern int readWord_t();
 
 audio_channel *	audio_channels[AUDIO_CHANNELS];	// Storage for the channel data
 
+TaskHandle_t audioHandlers[AUDIO_CHANNELS];     // Storage for audio handler task handlers
+
 // Audio channel driver task
 //
 void audio_driver(void * parameters) {
@@ -34,9 +36,15 @@ void init_audio_channel(int channel) {
     	4096,					// This stack size can be checked & adjusted by reading the Stack Highwater
         &channel,				// Parameters
         PLAY_SOUND_PRIORITY,	// Priority, with 3 (configMAX_PRIORITIES - 1) being the highest, and 0 being the lowest.
-        NULL,
+        &audioHandlers[channel],	// Task handle
     	ARDUINO_RUNNING_CORE
 	);
+}
+
+void audioTaskAbortDelay(int channel) {
+    if(audioHandlers[channel] != NULL) {
+        xTaskAbortDelay(audioHandlers[channel]);
+    }
 }
 
 // Initialise the sound driver

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -58,10 +58,10 @@ void init_audio() {
 
 // Send an audio acknowledgement
 //
-void sendPlayNote(int channel, int success) {
+void sendAudioStatus(int channel, int status) {
 	byte packet[] = {
 		channel,
-		success,
+		status,
 	};
 	send_packet(PACKET_AUDIO, sizeof packet, packet);
 }
@@ -95,7 +95,7 @@ void vdu_sys_audio() {
 			int frequency = readWord_t();	if(frequency == -1) return;
 			int duration = readWord_t();	if(duration == -1) return;
 
-			sendPlayNote(channel, play_note(channel, volume, frequency, duration));
+			sendAudioStatus(channel, play_note(channel, volume, frequency, duration));
 		}	break;
 	
 		case AUDIO_CMD_PLAYQUEUED: {
@@ -112,12 +112,24 @@ void vdu_sys_audio() {
 			debug_log("vdu_sys_audio: sample - not implemented yet\n\r");
 		}	break;
 
+		case AUDIO_CMD_VOLUME: {
+			debug_log("vdu_sys_audio: volume - not implemented yet\n\r");
+		}	break;
+
+		case AUDIO_CMD_FREQUENCY: {
+			debug_log("vdu_sys_audio: frequency - not implemented yet\n\r");
+		}	break;
+
 		case AUDIO_CMD_ENV_VOLUME: {
 			debug_log("vdu_sys_audio: env_volume - not implemented yet\n\r");
 		}	break;
 
 		case AUDIO_CMD_ENV_FREQUENCY: {
 			debug_log("vdu_sys_audio: env_frequency - not implemented yet\n\r");
+		}	break;
+
+		case AUDIO_CMD_STATUS: {
+			sendAudioStatus(channel, audio_channels[channel]->getStatus());
 		}	break;
 
 		case AUDIO_CMD_RESET: {

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -1,0 +1,112 @@
+//
+// Title:	        Audio VDU command support
+// Author:        	Steve Sims
+// Created:       	29/07/2023
+// Last Updated:	29/07/2023
+
+#pragma once
+
+#include "fabgl.h"
+
+fabgl::SoundGenerator		SoundGenerator;		// The audio class
+
+#include "agon.h"
+#include "agon_audio.h"
+
+extern void send_packet(byte code, byte len, byte data[]);
+extern int readByte_t();
+extern int readWord_t();
+
+audio_channel *	audio_channels[AUDIO_CHANNELS];	// Storage for the channel data
+
+// Audio channel driver task
+//
+void audio_driver(void * parameters) {
+	int channel = *(int *)parameters;
+
+	audio_channels[channel] = new audio_channel(channel);
+	while(true) {
+		audio_channels[channel]->loop();
+		vTaskDelay(1);
+	}
+}
+
+void init_audio_channel(int channel) {
+  	xTaskCreatePinnedToCore(audio_driver,  "audio_driver",
+    	4096,					// This stack size can be checked & adjusted by reading the Stack Highwater
+        &channel,				// Parameters
+        PLAY_SOUND_PRIORITY,	// Priority, with 3 (configMAX_PRIORITIES - 1) being the highest, and 0 being the lowest.
+        NULL,
+    	ARDUINO_RUNNING_CORE
+	);
+}
+
+// Initialise the sound driver
+//
+void init_audio() {
+	for(int i = 0; i < AUDIO_CHANNELS; i++) {
+		init_audio_channel(i);
+	}
+}
+
+// Send an audio acknowledgement
+//
+void sendPlayNote(int channel, int success) {
+	byte packet[] = {
+		channel,
+		success,
+	};
+	send_packet(PACKET_AUDIO, sizeof packet, packet);	
+}
+
+// Play a note
+//
+word play_note(byte channel, byte volume, word frequency, word duration) {
+	if(channel >=0 && channel < AUDIO_CHANNELS) {
+		return audio_channels[channel]->play_note(volume, frequency, duration);
+	}
+	return 1;
+}
+
+// Audio VDU command support (VDU 23, 0, &85, <args>)
+//
+void vdu_sys_audio() {
+	int channel = readByte_t();		if(channel == -1) return;
+	int command = readByte_t();		if(command == -1) return;
+
+	switch (command) {
+		case AUDIO_CMD_PLAY: {
+			int volume = readByte_t();		if(volume == -1) return;
+			int frequency = readWord_t();	if(frequency == -1) return;
+			int duration = readWord_t();	if(duration == -1) return;
+
+			sendPlayNote(channel, play_note(channel, volume, frequency, duration));
+		}	break;
+	
+		case AUDIO_CMD_PLAYQUEUED: {
+			debug_log("vdu_sys_audio: playqueued - not implemented yet\n");
+		} 	break;
+
+		case AUDIO_CMD_WAVEFORM: {
+			debug_log("vdu_sys_audio: waveform - not implemented yet\n");
+		}	break;
+
+		case AUDIO_CMD_SAMPLE: {
+			debug_log("vdu_sys_audio: sample - not implemented yet\n");
+		}	break;
+
+		case AUDIO_CMD_ENV_VOLUME: {
+			debug_log("vdu_sys_audio: env_volume - not implemented yet\n");
+		}	break;
+
+		case AUDIO_CMD_ENV_FREQUENCY: {
+			debug_log("vdu_sys_audio: env_frequency - not implemented yet\n");
+		}	break;
+
+		case AUDIO_CMD_RESET: {
+			debug_log("vdu_sys_audio: reset - not implemented yet\n");
+		}	break;
+	}
+}
+
+

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -208,7 +208,7 @@ void setVolumeEnvelope(byte channel, byte type) {
 				int decay = readWord_t();		if (decay == -1) return;
 				int sustain = readByte_t();		if (sustain == -1) return;
 				int release = readWord_t();		if (release == -1) return;
-				ADSRVolumeEnvelope *envelope = new ADSRVolumeEnvelope(attack, decay, sustain, release);
+				auto envelope = std::make_shared<ADSRVolumeEnvelope>(attack, decay, sustain, release);
 				audio_channels[channel]->setVolumeEnvelope(envelope);
 				break;
 		}

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -91,6 +91,14 @@ void setVolume(byte channel, byte volume) {
 	}
 }
 
+// Set channel frequency
+//
+void setFrequency(byte channel, word frequency) {
+	if(channel >=0 && channel < AUDIO_CHANNELS) {
+		audio_channels[channel]->setFrequency(frequency);
+	}
+}
+
 // Audio VDU command support (VDU 23, 0, &85, <args>)
 //
 void vdu_sys_audio() {
@@ -127,7 +135,9 @@ void vdu_sys_audio() {
 		}	break;
 
 		case AUDIO_CMD_FREQUENCY: {
-			debug_log("vdu_sys_audio: frequency - not implemented yet\n\r");
+			int frequency = readWord_t();	if(frequency == -1) return;
+
+			setFrequency(channel, frequency);
 		}	break;
 
 		case AUDIO_CMD_ENV_VOLUME: {

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -24,7 +24,7 @@ extern byte readByte_b();
 std::array<std::shared_ptr<audio_channel>, MAX_AUDIO_CHANNELS> audio_channels;
 std::vector<TaskHandle_t> audioHandlers;
 
-std::array<std::unique_ptr<audio_sample>, MAX_AUDIO_SAMPLES> samples;	// Storage for the sample data
+std::array<std::shared_ptr<audio_sample>, MAX_AUDIO_SAMPLES> samples;	// Storage for the sample data
 
 // Audio channel driver task
 //

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -4,9 +4,7 @@
 // Created:       	29/07/2023
 // Last Updated:	29/07/2023
 
-#pragma once
-
-#include "fabgl.h"
+#include <fabgl.h>
 
 fabgl::SoundGenerator		SoundGenerator;		// The audio class
 
@@ -47,6 +45,7 @@ void init_audio() {
 	for(int i = 0; i < AUDIO_CHANNELS; i++) {
 		init_audio_channel(i);
 	}
+    SoundGenerator.play(true);
 }
 
 // Send an audio acknowledgement
@@ -68,6 +67,13 @@ word play_note(byte channel, byte volume, word frequency, word duration) {
 	return 1;
 }
 
+// Set channel waveform
+void setWaveform(byte channel, byte waveformType) {
+    if(channel >=0 && channel < AUDIO_CHANNELS) {
+        audio_channels[channel]->setWaveform(waveformType);
+    }
+}
+
 // Audio VDU command support (VDU 23, 0, &85, <args>)
 //
 void vdu_sys_audio() {
@@ -84,27 +90,29 @@ void vdu_sys_audio() {
 		}	break;
 	
 		case AUDIO_CMD_PLAYQUEUED: {
-			debug_log("vdu_sys_audio: playqueued - not implemented yet\n");
+			debug_log("vdu_sys_audio: playqueued - not implemented yet\n\r");
 		} 	break;
 
 		case AUDIO_CMD_WAVEFORM: {
-			debug_log("vdu_sys_audio: waveform - not implemented yet\n");
+            int waveform = readByte_t();	if(waveform == -1) return;
+
+            setWaveform(channel, waveform);
 		}	break;
 
 		case AUDIO_CMD_SAMPLE: {
-			debug_log("vdu_sys_audio: sample - not implemented yet\n");
+			debug_log("vdu_sys_audio: sample - not implemented yet\n\r");
 		}	break;
 
 		case AUDIO_CMD_ENV_VOLUME: {
-			debug_log("vdu_sys_audio: env_volume - not implemented yet\n");
+			debug_log("vdu_sys_audio: env_volume - not implemented yet\n\r");
 		}	break;
 
 		case AUDIO_CMD_ENV_FREQUENCY: {
-			debug_log("vdu_sys_audio: env_frequency - not implemented yet\n");
+			debug_log("vdu_sys_audio: env_frequency - not implemented yet\n\r");
 		}	break;
 
 		case AUDIO_CMD_RESET: {
-			debug_log("vdu_sys_audio: reset - not implemented yet\n");
+			debug_log("vdu_sys_audio: reset - not implemented yet\n\r");
 		}	break;
 	}
 }

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -83,6 +83,14 @@ void setWaveform(byte channel, byte waveformType) {
 	}
 }
 
+// Set channel volume
+//
+void setVolume(byte channel, byte volume) {
+	if(channel >=0 && channel < AUDIO_CHANNELS) {
+		audio_channels[channel]->setVolume(volume);
+	}
+}
+
 // Audio VDU command support (VDU 23, 0, &85, <args>)
 //
 void vdu_sys_audio() {
@@ -113,7 +121,9 @@ void vdu_sys_audio() {
 		}	break;
 
 		case AUDIO_CMD_VOLUME: {
-			debug_log("vdu_sys_audio: volume - not implemented yet\n\r");
+			int volume = readByte_t();		if(volume == -1) return;
+
+			setVolume(channel, volume);
 		}	break;
 
 		case AUDIO_CMD_FREQUENCY: {

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -17,7 +17,7 @@ extern int readWord_t();
 
 audio_channel *	audio_channels[AUDIO_CHANNELS];	// Storage for the channel data
 
-TaskHandle_t audioHandlers[AUDIO_CHANNELS];     // Storage for audio handler task handlers
+TaskHandle_t audioHandlers[AUDIO_CHANNELS];		// Storage for audio handler task handlers
 
 // Audio channel driver task
 //
@@ -33,18 +33,18 @@ void audio_driver(void * parameters) {
 
 void init_audio_channel(int channel) {
   	xTaskCreatePinnedToCore(audio_driver,  "audio_driver",
-    	4096,					// This stack size can be checked & adjusted by reading the Stack Highwater
-        &channel,				// Parameters
-        PLAY_SOUND_PRIORITY,	// Priority, with 3 (configMAX_PRIORITIES - 1) being the highest, and 0 being the lowest.
-        &audioHandlers[channel],	// Task handle
-    	ARDUINO_RUNNING_CORE
+		4096,						// This stack size can be checked & adjusted by reading the Stack Highwater
+		&channel,					// Parameters
+		PLAY_SOUND_PRIORITY,		// Priority, with 3 (configMAX_PRIORITIES - 1) being the highest, and 0 being the lowest.
+		&audioHandlers[channel],	// Task handle
+		ARDUINO_RUNNING_CORE
 	);
 }
 
 void audioTaskAbortDelay(int channel) {
-    if(audioHandlers[channel] != NULL) {
-        xTaskAbortDelay(audioHandlers[channel]);
-    }
+	if(audioHandlers[channel] != NULL) {
+		xTaskAbortDelay(audioHandlers[channel]);
+	}
 }
 
 // Initialise the sound driver
@@ -53,7 +53,7 @@ void init_audio() {
 	for(int i = 0; i < AUDIO_CHANNELS; i++) {
 		init_audio_channel(i);
 	}
-    SoundGenerator.play(true);
+	SoundGenerator.play(true);
 }
 
 // Send an audio acknowledgement
@@ -63,7 +63,7 @@ void sendPlayNote(int channel, int success) {
 		channel,
 		success,
 	};
-	send_packet(PACKET_AUDIO, sizeof packet, packet);	
+	send_packet(PACKET_AUDIO, sizeof packet, packet);
 }
 
 // Play a note
@@ -76,10 +76,11 @@ word play_note(byte channel, byte volume, word frequency, word duration) {
 }
 
 // Set channel waveform
+//
 void setWaveform(byte channel, byte waveformType) {
-    if(channel >=0 && channel < AUDIO_CHANNELS) {
-        audio_channels[channel]->setWaveform(waveformType);
-    }
+	if(channel >=0 && channel < AUDIO_CHANNELS) {
+		audio_channels[channel]->setWaveform(waveformType);
+	}
 }
 
 // Audio VDU command support (VDU 23, 0, &85, <args>)
@@ -102,9 +103,9 @@ void vdu_sys_audio() {
 		} 	break;
 
 		case AUDIO_CMD_WAVEFORM: {
-            int waveform = readByte_t();	if(waveform == -1) return;
+			int waveform = readByte_t();	if(waveform == -1) return;
 
-            setWaveform(channel, waveform);
+			setWaveform(channel, waveform);
 		}	break;
 
 		case AUDIO_CMD_SAMPLE: {
@@ -124,5 +125,3 @@ void vdu_sys_audio() {
 		}	break;
 	}
 }
-
-

--- a/video/video.ino
+++ b/video/video.ino
@@ -246,6 +246,24 @@ int	readWord_t() {
 	return -1;
 }
 
+// Read an unsigned 24-bit value from the serial port, with a timeout
+// Returns:
+// - Value (0 to 16777215) if 3 bytes read, otherwise -1
+//
+int	read24_t() {
+	int	l = readByte_t();
+	if (l >= 0) {
+		int m = readByte_t();
+		if (m >= 0) {
+			int h = readByte_t();
+			if (h >= 0) {
+				return (h << 16) | (m << 8) | l;
+			}
+		}
+	}
+	return -1;
+}
+
 // Read an unsigned byte from the serial port (blocking)
 //
 byte readByte_b() {


### PR DESCRIPTION
Alternative audio enhancements, based in part on the work done by @HeathenUK in #31 

Taking inspiration from #31 this code re-purposes the unused "waveform" byte of VDU 23,0,&85 and uses it as a "command" indicator.  This allows for a wide variety of enhancements to be added to the audio system in an extensible way.  Compatibility with existing code is maintained by assuming that calls to VDU 23,0,&85 will have been made with the waveform byte set to zero.

The command set implemented is quite extensive, but essentially only offers facilities that one may have expected to find on 8-bit era machines.

Indefinite note playback is supported.  This can be achieved either by giving a duration of `-1` to the "play note" command, or by using the "volume" command to set the volume on a silent channel.  A channel playing an indefinite duration note is silenced by setting the volume to zero.
(NB BBC BASIC will need to be changed to support this, as when a duration value of -1 is set on a `SOUND` command it sends over a duration of 12750.)

Commands are present to allow for direct adjustment of volume and frequency on a channel.  This could potentially allow for complex audio envelopes to be managed by code running on the z80, potentially allowing BBC BASIC to implement the `ENVELOPE` command...  Rather than burdening the z80 with such things though there is support for envelopes within the VDP.

The "volume envelope" command applies an envelope to a channel, so all subsequent notes played on that channel will use the same envelope, much like on a synthesiser.  Only one envelope type, simple ADSR, is currently implemented.  This is similar to the ADSR support in #31 but in this version the "Release" phase of the envelope is interruptible, as that is typically how volume envelopes work.  The system can be quite easily extended to support other envelope types, and I may look to implement a type that would allow for functionality closer to the original BBC Micro's `ENVELOPE` functionality which allowed for the volume level during the "sustain" phase to gradually change.

Commands are also present (and implemented) to enable and disable audio channels, reset a channel, get the status of a channel, and also upload 16khz 8-bit PCM samples to the VDP.

This PR is in draft as there are two areas of functionality not yet finished.  Firstly the "frequency envelope" support has not yet been written - this will allow for changing frequencies like the invaders style sound @HeathenUK mentioned against his complexity 2 example in #31.  Secondly whilst samples can be uploaded to the VDP (and cleared), assigning them to a channel for playback has not yet been implemented.  I expect to implement sample playback by this time tomorrow.

I'll write up some documentation with examples soon.