### PR TITLE
Refactor code for readability and maintainability

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -15,10 +15,6 @@
 
 #pragma once
 
-#define	ESPSerial Serial2
-
-#define USE_HWFLOW				1		// Flow Control: 1 = enable hardware flow control to eZ80
-
 #define EPOCH_YEAR				1980	// 1-byte dates are offset from this (for FatFS)
 #define MAX_SPRITES				256		// Maximum number of sprites
 #define MAX_BITMAPS				256		// Maximum number of bitmaps

--- a/video/agon.h
+++ b/video/agon.h
@@ -1,11 +1,11 @@
 //
-// Title:	        Agon Video BIOS - Function prototypes
-// Author:        	Dean Belfield
-// Created:       	05/09/2022
-// Last Updated:    13/08/2023
+// Title:			Agon Video BIOS - Function prototypes
+// Author:			Dean Belfield
+// Created:			05/09/2022
+// Last Updated:	13/08/2023
 //
 // Modinfo:
-// 04/03/2023:      Added LOGICAL_SCRW and LOGICAL_SCRH
+// 04/03/2023:		Added LOGICAL_SCRW and LOGICAL_SCRH
 // 17/03/2023:		Added PACKET_RTC, EPOCH_YEAR, MAX_SPRITES, MAX_BITMAPS
 // 21/03/2023:		Added PACKET_KEYSTATE
 // 22/03/2023:		Added VDP codes
@@ -115,8 +115,8 @@
 #define VIEWPORT_GRAPHICS		2		// Graphics viewport
 #define VIEWPORT_ACTIVE			3		// Active viewport
 
-#define LOGICAL_SCRW            1280    // As per the BBC Micro standard
-#define LOGICAL_SCRH            1024
+#define LOGICAL_SCRW			1280	// As per the BBC Micro standard
+#define LOGICAL_SCRH			1024
 
 #if CONFIG_FREERTOS_UNICORE
 #define ARDUINO_RUNNING_CORE	0

--- a/video/agon.h
+++ b/video/agon.h
@@ -109,6 +109,12 @@
 #define AUDIO_STATE_RELEASE		4		// Channel is releasing a note
 #define AUDIO_STATE_ABORT		5		// Channel is aborting a note
 
+// Viewport definitions
+#define VIEWPORT_TEXT			0		// Text viewport
+#define VIEWPORT_DEFAULT		1		// Default (whole screen) viewport
+#define VIEWPORT_GRAPHICS		2		// Graphics viewport
+#define VIEWPORT_ACTIVE			3		// Active viewport
+
 #define LOGICAL_SCRW            1280    // As per the BBC Micro standard
 #define LOGICAL_SCRH            1024
 

--- a/video/agon_fonts.h
+++ b/video/agon_fonts.h
@@ -1,7 +1,7 @@
 //
-// Title:	        Agon Video BIOS - font file
-// Author:        	Damien Guard
-// Created:       	06/08/2022
+// Title:			Agon Video BIOS - font file
+// Author:			Damien Guard
+// Created:			06/08/2022
 // Last Updated:	20/02/2023
 //
 // Modinfo:

--- a/video/agon_keyboard.h
+++ b/video/agon_keyboard.h
@@ -149,6 +149,9 @@ bool wait_shiftkey(byte *ascii, byte* vk, byte* down) {
 	//
 	do {
 		kb->getNextVirtualKey(&item, 0);
+		*ascii = item.ASCII;
+		*vk = item.vk;
+		*down = item.down;
 		if (item.ASCII == 27) {	// Check for ESC
 			return false;
 		}

--- a/video/agon_keyboard.h
+++ b/video/agon_keyboard.h
@@ -1,0 +1,189 @@
+#ifndef AGON_KEYBOARD_H
+#define AGON_KEYBOARD_H
+
+#include <Arduino.h>
+#include <fabgl.h>
+
+#include "agon.h"
+#include "cursor.h"
+#include "vdp_protocol.h"
+
+fabgl::PS2Controller		PS2Controller;		// The keyboard class
+
+byte 			keycode = 0;					// Last pressed key code
+byte 			modifiers = 0;					// Last pressed key modifiers
+int				kbRepeatDelay = 500;			// Keyboard repeat delay ms (250, 500, 750 or 1000)		
+int				kbRepeatRate = 100;				// Keyboard repeat rate ms (between 33 and 500)
+
+// TODO refactor out sending keyboard info via VDP protocol
+
+// Keyboard setup
+//
+void setupKeyboard() {
+ 	PS2Controller.begin(PS2Preset::KeyboardPort0, KbdMode::CreateVirtualKeysQueue);
+	PS2Controller.keyboard()->setLayout(&fabgl::UKLayout);
+	PS2Controller.keyboard()->setCodePage(fabgl::CodePages::get(1252));
+	PS2Controller.keyboard()->setTypematicRateAndDelay(kbRepeatRate, kbRepeatDelay);
+}
+
+// Set keyboard layout
+//
+void setKeyboardLayout(int region) {
+    switch(region) {
+		case 1:	PS2Controller.keyboard()->setLayout(&fabgl::USLayout); break;
+		case 2:	PS2Controller.keyboard()->setLayout(&fabgl::GermanLayout); break;
+		case 3:	PS2Controller.keyboard()->setLayout(&fabgl::ItalianLayout); break;
+		case 4:	PS2Controller.keyboard()->setLayout(&fabgl::SpanishLayout); break;
+		case 5: PS2Controller.keyboard()->setLayout(&fabgl::FrenchLayout); break;
+		case 6:	PS2Controller.keyboard()->setLayout(&fabgl::BelgianLayout); break;
+		case 7:	PS2Controller.keyboard()->setLayout(&fabgl::NorwegianLayout); break;
+		case 8:	PS2Controller.keyboard()->setLayout(&fabgl::JapaneseLayout);break;
+		default:
+			PS2Controller.keyboard()->setLayout(&fabgl::UKLayout);
+			break;
+	}
+}
+
+// Handle the keyboard: BBC VDU Mode
+//
+void do_keyboard() {
+  	fabgl::Keyboard* kb = PS2Controller.keyboard();
+	fabgl::VirtualKeyItem item;
+
+	#if SERIALKB == 1
+	if (DBGSerial.available()) {
+		byte packet[] = {
+			DBGSerial.read(),
+			0,
+		};
+		send_packet(PACKET_KEYCODE, sizeof packet, packet);
+		return;
+	}
+	#endif
+	
+	if (kb->getNextVirtualKey(&item, 0)) {
+		if (item.down) {
+			switch (item.vk) {
+				case fabgl::VK_LEFT:
+					keycode = 0x08;
+					break;
+				case fabgl::VK_TAB:
+					keycode = 0x09;
+					break;
+				case fabgl::VK_RIGHT:
+					keycode = 0x15;
+					break;
+				case fabgl::VK_DOWN:
+					keycode = 0x0A;
+					break;
+				case fabgl::VK_UP:
+					keycode = 0x0B;
+					break;
+				case fabgl::VK_BACKSPACE:
+					keycode = 0x7F;
+					break;
+				default:
+					keycode = item.ASCII;	
+					break;
+			}
+			// Pack the modifiers into a byte
+			//
+			modifiers = 
+				item.CTRL		<< 0 |
+				item.SHIFT		<< 1 |
+				item.LALT		<< 2 |
+				item.RALT		<< 3 |
+				item.CAPSLOCK	<< 4 |
+				item.NUMLOCK	<< 5 |
+				item.SCROLLLOCK << 6 |
+				item.GUI		<< 7
+			;
+		}
+		// Handle some control keys
+		//
+		switch (keycode) {
+			case 14: setPagedMode(true); break;
+			case 15: setPagedMode(false); break;
+		}
+		// Create and send the packet back to MOS
+		//
+		byte packet[] = {
+			keycode,
+			modifiers,
+			item.vk,
+			item.down,
+		};
+		send_packet(PACKET_KEYCODE, sizeof packet, packet);
+	}
+}
+
+// Handle the keyboard: CP/M Terminal Mode
+// 
+void do_keyboard_terminal() {
+  	fabgl::Keyboard* kb = PS2Controller.keyboard();
+	fabgl::VirtualKeyItem item;
+
+	// Read the keyboard and transmit to the Z80
+	//
+	if (kb->getNextVirtualKey(&item, 0)) {
+		if (item.down) {
+			writeByte(item.ASCII);
+		}
+	}
+
+	// Wait for the response and write to the screen
+	//
+	while (byteAvailable()) {
+		Terminal.write(readByte());
+	}
+}
+
+// Wait for shift key to be released, then pressed (for paged mode)
+// 
+void wait_shiftkey() {
+  	fabgl::Keyboard* kb = PS2Controller.keyboard();
+	fabgl::VirtualKeyItem item;
+
+	// Wait for shift to be released
+	//
+	do {
+		kb->getNextVirtualKey(&item, 0);
+	} while (item.SHIFT);
+
+	// And pressed again
+	//
+	do {
+		kb->getNextVirtualKey(&item, 0);
+		if (item.ASCII == 27) {	// Check for ESC
+			byte packet[] = {
+				item.ASCII,
+				0,
+				item.vk,
+				item.down,
+			};
+			send_packet(PACKET_KEYCODE, sizeof packet, packet);
+			return;
+		}
+	} while (!item.SHIFT);
+}
+
+void getKeyboardState(int *repeatDelay, int *repeatRate, byte *ledState) {
+    bool numLock;
+	bool capsLock;
+	bool scrollLock;
+	PS2Controller.keyboard()->getLEDs(&numLock, &capsLock, &scrollLock);
+	*ledState = scrollLock | (capsLock << 1) | (numLock << 2);
+    *repeatDelay = kbRepeatDelay;
+    *repeatRate = kbRepeatRate;
+}
+
+void setKeyboardState(int delay, int rate, byte ledState) {
+    if (delay >= 250 && delay <= 1000) kbRepeatDelay = (delay / 250) * 250;	// In steps of 250ms
+	if (rate >=  33 && rate <=  500) kbRepeatRate  = rate;
+	if (ledState != 255) {
+		PS2Controller.keyboard()->setLEDs(ledState & 4, ledState & 2, ledState & 1);
+	}
+    PS2Controller.keyboard()->setTypematicRateAndDelay(kbRepeatRate, kbRepeatDelay);
+}
+
+#endif // AGON_KEYBOARD_H

--- a/video/agon_keyboard.h
+++ b/video/agon_keyboard.h
@@ -5,22 +5,19 @@
 #include <fabgl.h>
 
 #include "agon.h"
-#include "cursor.h"
 #include "vdp_protocol.h"
 
 fabgl::PS2Controller		PS2Controller;		// The keyboard class
 
-byte 			keycode = 0;					// Last pressed key code
-byte 			modifiers = 0;					// Last pressed key modifiers
+byte			_keycode = 0;					// Last pressed key code
+byte			_modifiers = 0;					// Last pressed key modifiers
 int				kbRepeatDelay = 500;			// Keyboard repeat delay ms (250, 500, 750 or 1000)		
 int				kbRepeatRate = 100;				// Keyboard repeat rate ms (between 33 and 500)
-
-// TODO refactor out sending keyboard info via VDP protocol
 
 // Keyboard setup
 //
 void setupKeyboard() {
- 	PS2Controller.begin(PS2Preset::KeyboardPort0, KbdMode::CreateVirtualKeysQueue);
+	PS2Controller.begin(PS2Preset::KeyboardPort0, KbdMode::CreateVirtualKeysQueue);
 	PS2Controller.keyboard()->setLayout(&fabgl::UKLayout);
 	PS2Controller.keyboard()->setCodePage(fabgl::CodePages::get(1252));
 	PS2Controller.keyboard()->setTypematicRateAndDelay(kbRepeatRate, kbRepeatDelay);
@@ -29,7 +26,7 @@ void setupKeyboard() {
 // Set keyboard layout
 //
 void setKeyboardLayout(int region) {
-    switch(region) {
+	switch(region) {
 		case 1:	PS2Controller.keyboard()->setLayout(&fabgl::USLayout); break;
 		case 2:	PS2Controller.keyboard()->setLayout(&fabgl::GermanLayout); break;
 		case 3:	PS2Controller.keyboard()->setLayout(&fabgl::ItalianLayout); break;
@@ -44,20 +41,21 @@ void setKeyboardLayout(int region) {
 	}
 }
 
-// Handle the keyboard: BBC VDU Mode
+// Get keyboard key presses
+// returns true only if there's a new keypress update
 //
-void do_keyboard() {
-  	fabgl::Keyboard* kb = PS2Controller.keyboard();
+bool getKeyboardKey(byte *keycode, byte *modifiers, byte *vk, byte *down) {
+	fabgl::Keyboard* kb = PS2Controller.keyboard();
 	fabgl::VirtualKeyItem item;
 
 	#if SERIALKB == 1
 	if (DBGSerial.available()) {
-		byte packet[] = {
-			DBGSerial.read(),
-			0,
-		};
-		send_packet(PACKET_KEYCODE, sizeof packet, packet);
-		return;
+		_keycode = DBGSerial.read();
+		*keycode = _keycode;
+		*modifiers = 0;
+		*vk = 0;
+		*down = 0;
+		return true;
 	}
 	#endif
 	
@@ -65,30 +63,30 @@ void do_keyboard() {
 		if (item.down) {
 			switch (item.vk) {
 				case fabgl::VK_LEFT:
-					keycode = 0x08;
+					_keycode = 0x08;
 					break;
 				case fabgl::VK_TAB:
-					keycode = 0x09;
+					_keycode = 0x09;
 					break;
 				case fabgl::VK_RIGHT:
-					keycode = 0x15;
+					_keycode = 0x15;
 					break;
 				case fabgl::VK_DOWN:
-					keycode = 0x0A;
+					_keycode = 0x0A;
 					break;
 				case fabgl::VK_UP:
-					keycode = 0x0B;
+					_keycode = 0x0B;
 					break;
 				case fabgl::VK_BACKSPACE:
-					keycode = 0x7F;
+					_keycode = 0x7F;
 					break;
 				default:
-					keycode = item.ASCII;	
+					_keycode = item.ASCII;	
 					break;
 			}
 			// Pack the modifiers into a byte
 			//
-			modifiers = 
+			_modifiers = 
 				item.CTRL		<< 0 |
 				item.SHIFT		<< 1 |
 				item.LALT		<< 2 |
@@ -99,49 +97,39 @@ void do_keyboard() {
 				item.GUI		<< 7
 			;
 		}
-		// Handle some control keys
-		//
-		switch (keycode) {
-			case 14: setPagedMode(true); break;
-			case 15: setPagedMode(false); break;
-		}
-		// Create and send the packet back to MOS
-		//
-		byte packet[] = {
-			keycode,
-			modifiers,
-			item.vk,
-			item.down,
-		};
-		send_packet(PACKET_KEYCODE, sizeof packet, packet);
+		*keycode = _keycode;
+		*modifiers = _modifiers;
+		*vk = item.vk;
+		*down = item.down;
+
+		return true;
 	}
+
+	return false;
 }
 
-// Handle the keyboard: CP/M Terminal Mode
-// 
-void do_keyboard_terminal() {
-  	fabgl::Keyboard* kb = PS2Controller.keyboard();
+// Simpler keyboard read for CP/M Terminal Mode
+//
+bool getKeyboardKey(byte *ascii) {
+	fabgl::Keyboard* kb = PS2Controller.keyboard();
 	fabgl::VirtualKeyItem item;
 
 	// Read the keyboard and transmit to the Z80
 	//
 	if (kb->getNextVirtualKey(&item, 0)) {
 		if (item.down) {
-			writeByte(item.ASCII);
+			*ascii = item.ASCII;
+			return true;
 		}
 	}
 
-	// Wait for the response and write to the screen
-	//
-	while (byteAvailable()) {
-		Terminal.write(readByte());
-	}
+	return false;
 }
 
-// Wait for shift key to be released, then pressed (for paged mode)
+// Wait for shift key to be released, then pressed (used for paged mode)
 // 
-void wait_shiftkey() {
-  	fabgl::Keyboard* kb = PS2Controller.keyboard();
+bool wait_shiftkey(byte *ascii, byte* vk, byte* down) {
+	fabgl::Keyboard* kb = PS2Controller.keyboard();
 	fabgl::VirtualKeyItem item;
 
 	// Wait for shift to be released
@@ -155,20 +143,15 @@ void wait_shiftkey() {
 	do {
 		kb->getNextVirtualKey(&item, 0);
 		if (item.ASCII == 27) {	// Check for ESC
-			byte packet[] = {
-				item.ASCII,
-				0,
-				item.vk,
-				item.down,
-			};
-			send_packet(PACKET_KEYCODE, sizeof packet, packet);
-			return;
+			return false;
 		}
 	} while (!item.SHIFT);
+
+	return true;
 }
 
 void getKeyboardState(int *repeatDelay, int *repeatRate, byte *ledState) {
-    bool numLock;
+	bool numLock;
 	bool capsLock;
 	bool scrollLock;
 	PS2Controller.keyboard()->getLEDs(&numLock, &capsLock, &scrollLock);
@@ -178,7 +161,7 @@ void getKeyboardState(int *repeatDelay, int *repeatRate, byte *ledState) {
 }
 
 void setKeyboardState(int delay, int rate, byte ledState) {
-    if (delay >= 250 && delay <= 1000) kbRepeatDelay = (delay / 250) * 250;	// In steps of 250ms
+	if (delay >= 250 && delay <= 1000) kbRepeatDelay = (delay / 250) * 250;	// In steps of 250ms
 	if (rate >=  33 && rate <=  500) kbRepeatRate  = rate;
 	if (ledState != 255) {
 		PS2Controller.keyboard()->setLEDs(ledState & 4, ledState & 2, ledState & 1);

--- a/video/agon_screen.h
+++ b/video/agon_screen.h
@@ -125,8 +125,8 @@ void switchBuffer() {
 
 // Wait for plot completion
 //
-void waitPlotCompletion() {
-	Canvas->waitCompletion(false);
+inline void waitPlotCompletion(bool waitForVSync = false) {
+	Canvas->waitCompletion(waitForVSync);
 }
 
 #endif // AGON_SCREEN_H

--- a/video/agon_screen.h
+++ b/video/agon_screen.h
@@ -1,0 +1,124 @@
+#ifndef AGON_SCREEN_H
+#define AGON_SCREEN_H
+
+#include <fabgl.h>
+
+fabgl::Canvas *				Canvas;				// The canvas class
+
+fabgl::VGA2Controller		VGAController2;		// VGA class - 2 colours
+fabgl::VGA4Controller		VGAController4;		// VGA class - 4 colours
+fabgl::VGA8Controller		VGAController8;		// VGA class - 8 colours
+fabgl::VGA16Controller		VGAController16;	// VGA class - 16 colours
+fabgl::VGAController		VGAController64;	// VGA class - 64 colours
+
+fabgl::VGABaseController *	VGAController;		// Pointer to the current VGA controller class (one of the above)
+
+int				_VGAColourDepth;				// Number of colours per pixel (2, 4, 8, 16 or 64)
+bool			doubleBuffered = false;			// Disable double buffering by default
+
+
+// Get controller
+// Parameters:
+// - colours: Number of colours per pixel (2, 4, 8, 16 or 64)
+// Returns:
+// - A singleton instance of a VGAController class
+//
+fabgl::VGABaseController * getVGAController(int colours = _VGAColourDepth) {
+	switch (colours) {
+		case  2: return VGAController2.instance();
+		case  4: return VGAController4.instance();
+		case  8: return VGAController8.instance();
+		case 16: return VGAController16.instance();
+		case 64: return VGAController64.instance();
+	}
+	return nullptr;
+}
+
+// Update the internal FabGL LUT
+//
+void updateRGB2PaletteLUT() {
+	switch (_VGAColourDepth) {
+		case 2: VGAController2.updateRGB2PaletteLUT(); break;
+		case 4: VGAController4.updateRGB2PaletteLUT(); break;
+		case 8: VGAController8.updateRGB2PaletteLUT(); break;
+		case 16: VGAController16.updateRGB2PaletteLUT(); break;
+	}
+}
+
+// Get current colour depth
+//
+inline int getVGAColourDepth() {
+    return _VGAColourDepth;
+}
+
+// Set a palette item
+// Parameters:
+// - l: The logical colour to change
+// - c: The new colour
+// 
+void setPaletteItem(int l, RGB888 c) {
+    int depth = getVGAColourDepth();
+	if (l < depth) {
+		switch (depth) {
+			case 2: VGAController2.setPaletteItem(l, c); break;
+			case 4: VGAController4.setPaletteItem(l, c); break;
+			case 8: VGAController8.setPaletteItem(l, c); break;
+			case 16: VGAController16.setPaletteItem(l, c); break;
+		}
+	}
+}
+
+// Change video resolution
+// Parameters:
+// - colours: Number of colours per pixel (2, 4, 8, 16 or 64)
+// - modeLine: A modeline string (see the FagGL documentation for more details)
+// Returns:
+// - 0: Successful
+// - 1: Invalid # of colours
+// - 2: Not enough memory for mode
+//
+int change_resolution(int colours, char * modeLine) {
+	fabgl::VGABaseController * controller = getVGAController(colours);
+
+	if (controller == nullptr) {					// If controller is null, then an invalid # of colours was passed
+		return 1;									// So return the error
+	}
+  	delete Canvas;									// Delete the canvas
+
+	_VGAColourDepth = colours;						// Set the number of colours per pixel
+	if (VGAController != controller) {				// Is it a different controller?
+		if (VGAController) {						// If there is an existing controller running then
+			VGAController->end();					// end it
+		}
+		VGAController = controller;					// Switch to the new controller
+		VGAController->begin();						// And spin it up
+	}
+	if (modeLine) {									// If modeLine is not a null pointer then
+		if (doubleBuffered == true) {
+			VGAController->setResolution(modeLine, -1, -1, 1);
+		} else {
+			VGAController->setResolution(modeLine);	// Set the resolution
+		}
+	} else {
+        debug_log("change_resolution: modeLine is null\n\r");
+    }
+	VGAController->enableBackgroundPrimitiveExecution(true);
+	VGAController->enableBackgroundPrimitiveTimeout(false);
+
+  	Canvas = new fabgl::Canvas(VGAController);		// Create the new canvas
+	//
+	// Check whether the selected mode has enough memory for the vertical resolution
+	//
+	if (VGAController->getScreenHeight() != VGAController->getViewPortHeight()) {
+		return 2;
+	}
+	return 0;										// Return with no errors
+}
+
+void switchBuffer() {
+	if (doubleBuffered == true) {
+		Canvas->swapBuffers();
+	}
+}
+
+#endif // AGON_SCREEN_H

--- a/video/agon_screen.h
+++ b/video/agon_screen.h
@@ -48,7 +48,7 @@ void updateRGB2PaletteLUT() {
 // Get current colour depth
 //
 inline int getVGAColourDepth() {
-    return _VGAColourDepth;
+	return _VGAColourDepth;
 }
 
 // Set a palette item
@@ -57,7 +57,7 @@ inline int getVGAColourDepth() {
 // - c: The new colour
 // 
 void setPaletteItem(int l, RGB888 c) {
-    int depth = getVGAColourDepth();
+	int depth = getVGAColourDepth();
 	if (l < depth) {
 		switch (depth) {
 			case 2: VGAController2.setPaletteItem(l, c); break;
@@ -83,7 +83,7 @@ int change_resolution(int colours, char * modeLine) {
 	if (controller == nullptr) {					// If controller is null, then an invalid # of colours was passed
 		return 1;									// So return the error
 	}
-  	delete Canvas;									// Delete the canvas
+	delete Canvas;									// Delete the canvas
 
 	_VGAColourDepth = colours;						// Set the number of colours per pixel
 	if (VGAController != controller) {				// Is it a different controller?
@@ -100,12 +100,12 @@ int change_resolution(int colours, char * modeLine) {
 			VGAController->setResolution(modeLine);	// Set the resolution
 		}
 	} else {
-        debug_log("change_resolution: modeLine is null\n\r");
-    }
+		debug_log("change_resolution: modeLine is null\n\r");
+	}
 	VGAController->enableBackgroundPrimitiveExecution(true);
 	VGAController->enableBackgroundPrimitiveTimeout(false);
 
-  	Canvas = new fabgl::Canvas(VGAController);		// Create the new canvas
+	Canvas = new fabgl::Canvas(VGAController);		// Create the new canvas
 	//
 	// Check whether the selected mode has enough memory for the vertical resolution
 	//
@@ -115,10 +115,18 @@ int change_resolution(int colours, char * modeLine) {
 	return 0;										// Return with no errors
 }
 
+// Swap to other buffer if we're in a double-buffered mode
+//
 void switchBuffer() {
 	if (doubleBuffered == true) {
 		Canvas->swapBuffers();
 	}
+}
+
+// Wait for plot completion
+//
+void waitPlotCompletion() {
+	Canvas->waitCompletion(false);
 }
 
 #endif // AGON_SCREEN_H

--- a/video/cursor.h
+++ b/video/cursor.h
@@ -4,13 +4,14 @@
 #include <fabgl.h>
 #include <Arduino.h>
 
+#include "agon_keyboard.h"
 #include "vdp_protocol.h"
 #include "viewport.h"
 
 extern int		fontW;
 extern int		fontH;
 extern fabgl::Canvas * Canvas;
-extern void wait_shiftkey();
+extern void wait_shiftkey();	// defined by agon_keyboard.h
 
 Point			textCursor;						// Text cursor
 Point *			activeCursor;					// Pointer to the active text cursor (textCursor or p1)

--- a/video/cursor.h
+++ b/video/cursor.h
@@ -1,0 +1,156 @@
+#ifndef CURSOR_H
+#define CURSOR_H
+
+#include <fabgl.h>
+#include <Arduino.h>
+
+#include "vdp_protocol.h"
+#include "viewport.h"
+
+extern int		fontW;
+extern int		fontH;
+extern fabgl::Canvas * Canvas;
+extern void wait_shiftkey();
+
+Point			textCursor;						// Text cursor
+Point *			activeCursor;					// Pointer to the active text cursor (textCursor or p1)
+bool			cursorEnabled = true;			// Cursor visibility
+byte			cursorBehaviour = 0;			// Cursor behavior
+bool 			pagedMode = false;				// Is output paged or not? Set by VDU 14 and 15
+int				pagedModeCount = 0;				// Scroll counter for paged mode
+
+
+// Render a cursor at the current screen position
+//
+void do_cursor() {
+	if (cursorEnabled) {
+		Canvas->swapRectangle(textCursor.X, textCursor.Y, textCursor.X + fontW - 1, textCursor.Y + fontH - 1);
+	}
+}
+
+// Move the active cursor to the leftmost position in the viewport
+//
+void cursorCR() {
+  	activeCursor->X = activeViewport->X1;
+}
+
+// Move the active cursor down a line
+//
+void cursorDown() {
+	activeCursor->Y += fontH;
+	//
+	// If in graphics mode, then don't scroll, wrap to top
+	// 
+	if (activeCursor != &textCursor) {
+		if (activeCursor->Y > activeViewport->Y2) {	
+			activeCursor->Y = activeViewport->Y2;
+		}
+		return;
+	}
+	//
+	// Using the text cursor, so handle paging and scrolling
+	//
+	if (pagedMode) {
+		pagedModeCount++;
+		if (pagedModeCount >= (activeViewport->Y2 - activeViewport->Y1 + 1) / fontH) {
+			pagedModeCount = 0;
+			wait_shiftkey();
+		}
+	}
+	//
+	// Check if scroll required
+	//
+	if (activeCursor->Y > activeViewport->Y2) {
+		activeCursor->Y -= fontH;
+		if (~cursorBehaviour & 0x01) {
+			Canvas->setScrollingRegion(activeViewport->X1, activeViewport->Y1, activeViewport->X2, activeViewport->Y2);
+			Canvas->scroll(0, -fontH);
+		}
+		else {
+			activeCursor->X = activeViewport->X2 + 1;
+		}
+	}
+}
+
+// Move the active cursor up a line
+//
+void cursorUp() {	
+  	activeCursor->Y -= fontH;
+  	if (activeCursor->Y < activeViewport->Y1) {
+		activeCursor->Y = activeViewport->Y1;
+  	}
+}
+
+// Move the active cursor back one character
+//
+void cursorLeft() {
+	activeCursor->X -= fontW;											
+	if (activeCursor->X < activeViewport->X1) {								// If moved past left edge of active viewport then
+		activeCursor->X = activeViewport->X1;								// Lock it there
+	}
+}
+
+// Advance the active cursor right one character
+//
+void cursorRight() {
+  	activeCursor->X += fontW;											
+  	if (activeCursor->X > activeViewport->X2) {								// If advanced past right edge of active viewport
+		if (activeCursor == &textCursor || (~cursorBehaviour & 0x40)) {		// If it is a text cursor or VDU 5 CR/LF is enabled then
+			cursorCR();														// Do carriage return
+   			cursorDown();													// and line feed
+		}
+  	}
+}
+
+// Move the active cursor to the top-left position in the viewport
+//
+void cursorHome() {
+	activeCursor->X = activeViewport->X1;
+	activeCursor->Y = activeViewport->Y1;
+}
+
+// TAB(x,y)
+//
+void cursorTab(int x, int y) {
+	activeCursor->X = x * fontW;
+	activeCursor->Y = y * fontH;
+}
+
+// Reset basic cursor control
+//
+void resetCursor() {
+	activeCursor = &textCursor;
+	cursorEnabled = true;
+	cursorBehaviour = 0;
+	pagedMode = false;
+}
+
+void homeCursor() {
+	textCursor = Point(activeViewport->X1, activeViewport->Y1);
+}
+
+void enableCursor(bool enable = true) {
+	cursorEnabled = enable;
+}
+
+void setPagedMode(bool mode = pagedMode) {
+	pagedMode = mode;
+	pagedModeCount = 0;
+}
+
+void ensureCursorInViewport(Rect viewport) {
+	if (activeCursor->X < viewport.X1
+		|| activeCursor->X > viewport.X2
+		|| activeCursor->Y < viewport.Y1
+		|| activeCursor->Y > viewport.Y2
+		) {
+		activeCursor->X = viewport.X1;
+		activeCursor->Y = viewport.Y1;
+	}
+}
+
+void setCursorBehaviour(byte setting, byte mask = 0xFF) {
+	cursorBehaviour = (cursorBehaviour & mask) ^ setting;
+}
+
+#endif	// CURSOR_H

--- a/video/cursor.h
+++ b/video/cursor.h
@@ -11,7 +11,6 @@
 extern int		fontW;
 extern int		fontH;
 extern fabgl::Canvas * Canvas;
-extern void wait_shiftkey();	// defined by agon_keyboard.h
 
 Point			textCursor;						// Text cursor
 Point *			activeCursor;					// Pointer to the active text cursor (textCursor or p1)
@@ -55,7 +54,19 @@ void cursorDown() {
 		pagedModeCount++;
 		if (pagedModeCount >= (activeViewport->Y2 - activeViewport->Y1 + 1) / fontH) {
 			pagedModeCount = 0;
-			wait_shiftkey();
+			byte ascii;
+			byte vk;
+			byte down;
+			if (!wait_shiftkey(&ascii, &vk, &down)) {
+				// ESC pressed
+				byte packet[] = {
+					ascii,
+					0,
+					vk,
+					down,
+				};
+				send_packet(PACKET_KEYCODE, sizeof packet, packet);
+			}
 		}
 	}
 	//

--- a/video/cursor.h
+++ b/video/cursor.h
@@ -30,6 +30,22 @@ void do_cursor() {
 	}
 }
 
+inline Point * getTextCursor() {
+	return &textCursor;
+}
+
+inline bool textCursorActive() {
+	return activeCursor == &textCursor;
+}
+
+inline void setActiveCursor(Point * cursor) {
+	activeCursor = cursor;
+}
+
+inline void setCursorBehaviour(byte setting, byte mask = 0xFF) {
+	cursorBehaviour = (cursorBehaviour & mask) ^ setting;
+}
+
 // Move the active cursor to the leftmost position in the viewport
 //
 void cursorCR() {
@@ -43,7 +59,7 @@ void cursorDown() {
 	//
 	// If in graphics mode, then don't scroll, wrap to top
 	// 
-	if (activeCursor != &textCursor) {
+	if (!textCursorActive()) {
 		if (activeCursor->Y > activeViewport->Y2) {	
 			activeCursor->Y = activeViewport->Y2;
 		}
@@ -98,8 +114,8 @@ void cursorUp() {
 //
 void cursorLeft() {
 	activeCursor->X -= fontW;											
-	if (activeCursor->X < activeViewport->X1) {								// If moved past left edge of active viewport then
-		activeCursor->X = activeViewport->X1;								// Lock it there
+	if (activeCursor->X < activeViewport->X1) {						// If moved past left edge of active viewport then
+		activeCursor->X = activeViewport->X1;						// Lock it there
 	}
 }
 
@@ -107,10 +123,10 @@ void cursorLeft() {
 //
 void cursorRight() {
 	activeCursor->X += fontW;											
-	if (activeCursor->X > activeViewport->X2) {								// If advanced past right edge of active viewport
-		if (activeCursor == &textCursor || (~cursorBehaviour & 0x40)) {		// If it is a text cursor or VDU 5 CR/LF is enabled then
-			cursorCR();														// Do carriage return
-			cursorDown();													// and line feed
+	if (activeCursor->X > activeViewport->X2) {						// If advanced past right edge of active viewport
+		if (textCursorActive() || (~cursorBehaviour & 0x40)) {		// If it is a text cursor or VDU 5 CR/LF is enabled then
+			cursorCR();												// Do carriage return
+			cursorDown();											// and line feed
 		}
 	}
 }
@@ -137,7 +153,7 @@ void setPagedMode(bool mode = pagedMode) {
 // Reset basic cursor control
 //
 void resetCursor() {
-	activeCursor = &textCursor;
+	setActiveCursor(getTextCursor());
 	cursorEnabled = true;
 	cursorBehaviour = 0;
 	setPagedMode(false);
@@ -160,22 +176,6 @@ void ensureCursorInViewport(Rect viewport) {
 		activeCursor->X = viewport.X1;
 		activeCursor->Y = viewport.Y1;
 	}
-}
-
-inline void setCursorBehaviour(byte setting, byte mask = 0xFF) {
-	cursorBehaviour = (cursorBehaviour & mask) ^ setting;
-}
-
-inline Point * getTextCursor() {
-	return &textCursor;
-}
-
-inline void setActiveCursor(Point * cursor) {
-	activeCursor = cursor;
-}
-
-inline bool textCursorActive() {
-	return activeCursor == &textCursor;
 }
 
 #endif	// CURSOR_H

--- a/video/cursor.h
+++ b/video/cursor.h
@@ -11,7 +11,6 @@
 
 extern int		fontW;
 extern int		fontH;
-extern fabgl::Canvas * Canvas;
 extern void drawCursor(Point p);
 extern void scrollRegion(Rect * r, int direction, int amount);
 
@@ -34,7 +33,7 @@ void do_cursor() {
 // Move the active cursor to the leftmost position in the viewport
 //
 void cursorCR() {
-  	activeCursor->X = activeViewport->X1;
+	activeCursor->X = activeViewport->X1;
 }
 
 // Move the active cursor down a line
@@ -88,11 +87,11 @@ void cursorDown() {
 
 // Move the active cursor up a line
 //
-void cursorUp() {	
-  	activeCursor->Y -= fontH;
-  	if (activeCursor->Y < activeViewport->Y1) {
+void cursorUp() {
+	activeCursor->Y -= fontH;
+	if (activeCursor->Y < activeViewport->Y1) {
 		activeCursor->Y = activeViewport->Y1;
-  	}
+	}
 }
 
 // Move the active cursor back one character
@@ -107,13 +106,13 @@ void cursorLeft() {
 // Advance the active cursor right one character
 //
 void cursorRight() {
-  	activeCursor->X += fontW;											
-  	if (activeCursor->X > activeViewport->X2) {								// If advanced past right edge of active viewport
+	activeCursor->X += fontW;											
+	if (activeCursor->X > activeViewport->X2) {								// If advanced past right edge of active viewport
 		if (activeCursor == &textCursor || (~cursorBehaviour & 0x40)) {		// If it is a text cursor or VDU 5 CR/LF is enabled then
 			cursorCR();														// Do carriage return
-   			cursorDown();													// and line feed
+			cursorDown();													// and line feed
 		}
-  	}
+	}
 }
 
 // Move the active cursor to the top-left position in the viewport
@@ -148,7 +147,7 @@ void homeCursor() {
 	textCursor = Point(activeViewport->X1, activeViewport->Y1);
 }
 
-void enableCursor(bool enable = true) {
+inline void enableCursor(bool enable = true) {
 	cursorEnabled = enable;
 }
 
@@ -163,19 +162,19 @@ void ensureCursorInViewport(Rect viewport) {
 	}
 }
 
-void setCursorBehaviour(byte setting, byte mask = 0xFF) {
+inline void setCursorBehaviour(byte setting, byte mask = 0xFF) {
 	cursorBehaviour = (cursorBehaviour & mask) ^ setting;
 }
 
-Point * getTextCursor() {
+inline Point * getTextCursor() {
 	return &textCursor;
 }
 
-void setActiveCursor(Point * cursor) {
+inline void setActiveCursor(Point * cursor) {
 	activeCursor = cursor;
 }
 
-bool textCursorActive() {
+inline bool textCursorActive() {
 	return activeCursor == &textCursor;
 }
 

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -142,7 +142,7 @@ void setPalette(int l, int p, int r, int g, int b) {
 			return;
 		}
 		setPaletteItem(l, col);
-		Canvas->waitCompletion(false);
+		waitPlotCompletion();
 		debug_log("vdu_palette: %d,%d,%d,%d,%d\n\r", l, p, r, g, b);
 	} else {
 		debug_log("vdu_palette: not supported in this mode\n\r");
@@ -597,7 +597,7 @@ void scrollRegion(Rect * region, int direction, int movement) {
 			Canvas->scroll(0, -movement);
 			break;
 	}
-	Canvas->waitCompletion(false);
+	waitPlotCompletion();
 }
 
 #endif

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -82,7 +82,7 @@ char getScreenChar(int px, int py) {
 	for (int y = 0; y < 8; y++) {
 		charRow = 0;
 		for (int x = 0; x < 8; x++) {
-			pixel = Canvas->getPixel(px + x, py + y);
+			pixel = canvas->getPixel(px + x, py + y);
 			if (!(pixel.R == R && pixel.G == G && pixel.B == B)) {
 				charRow |= (0x80 >> x);
 			}
@@ -105,7 +105,7 @@ char getScreenChar(int px, int py) {
 RGB888 getPixel(int x, int y) {
 	Point p = translateViewport(scale(x, y));
 	if (p.X >= 0 && p.Y >= 0 && p.X < canvasW && p.Y < canvasH) {
-		return Canvas->getPixel(p.X, p.Y);
+		return canvas->getPixel(p.X, p.Y);
 	}
 	return RGB888(0,0,0);
 }
@@ -220,12 +220,12 @@ void setGraphicsColour(byte mode, byte colour) {
 // Clear a viewport
 //
 void clearViewport(Rect * viewport) {
-	if (Canvas) {
+	if (canvas) {
 		if (useViewports) {
-			Canvas->fillRectangle(*viewport);
+			canvas->fillRectangle(*viewport);
 		}
 		else {
-			Canvas->clear();
+			canvas->clear();
 		}
 	}
 }
@@ -252,27 +252,27 @@ Point * getGraphicsCursor() {
 // Set up canvas for drawing graphics
 //
 void setGraphicsOptions() {
-	Canvas->setClippingRect(graphicsViewport);
-	Canvas->setPenColor(gfg);
-	Canvas->setPaintOptions(gpo);
+	canvas->setClippingRect(graphicsViewport);
+	canvas->setPenColor(gfg);
+	canvas->setPaintOptions(gpo);
 }
 
 // Move to
 //
 void moveTo() {
-	Canvas->moveTo(p1.X, p1.Y);
+	canvas->moveTo(p1.X, p1.Y);
 }
 
 // Line plot
 //
 void plotLine() {
-	Canvas->lineTo(p1.X, p1.Y);
+	canvas->lineTo(p1.X, p1.Y);
 }
 
 // Point point
 //
 void plotPoint() {
-	Canvas->setPixel(p1.X, p1.Y);
+	canvas->setPixel(p1.X, p1.Y);
 }
 
 // Triangle plot
@@ -283,9 +283,9 @@ void plotTriangle(byte mode) {
 		p2,
 		p1, 
 	};
-	Canvas->setBrushColor(gfg);
-	Canvas->fillPath(p, 3);
-	Canvas->setBrushColor(tbg);
+	canvas->setBrushColor(gfg);
+	canvas->fillPath(p, 3);
+	canvas->setBrushColor(tbg);
 }
 
 // Circle plot
@@ -295,13 +295,13 @@ void plotCircle(byte mode) {
 	switch (mode) {
 		case 0x00 ... 0x03: // Circle
 			r = 2 * (p1.X + p1.Y);
-			Canvas->drawEllipse(p2.X, p2.Y, r, r);
+			canvas->drawEllipse(p2.X, p2.Y, r, r);
 			break;
 		case 0x04 ... 0x07: // Circle
 			a = p2.X - p1.X;
 			b = p2.Y - p1.Y;
 			r = 2 * sqrt(a * a + b * b);
-			Canvas->drawEllipse(p2.X, p2.Y, r, r);
+			canvas->drawEllipse(p2.X, p2.Y, r, r);
 		break;
 	}
 }
@@ -310,17 +310,17 @@ void plotCircle(byte mode) {
 //
 void plotCharacter(char c) {
 	if (textCursorActive()) {
-		Canvas->setClippingRect(defaultViewport);
-		Canvas->setPenColor(tfg);
-		Canvas->setBrushColor(tbg);
-		Canvas->setPaintOptions(tpo);
+		canvas->setClippingRect(defaultViewport);
+		canvas->setPenColor(tfg);
+		canvas->setBrushColor(tbg);
+		canvas->setPaintOptions(tpo);
 	}
 	else {
-		Canvas->setClippingRect(graphicsViewport);
-		Canvas->setPenColor(gfg);
-		Canvas->setPaintOptions(gpo);
+		canvas->setClippingRect(graphicsViewport);
+		canvas->setPenColor(gfg);
+		canvas->setPaintOptions(gpo);
 	}
-	Canvas->drawChar(activeCursor->X, activeCursor->Y, c);
+	canvas->drawChar(activeCursor->X, activeCursor->Y, c);
 	cursorRight();
 }
 
@@ -328,26 +328,26 @@ void plotCharacter(char c) {
 //
 void plotBackspace() {
 	cursorLeft();
-	Canvas->setBrushColor(textCursorActive() ? tbg : gbg);
-	Canvas->fillRectangle(activeCursor->X, activeCursor->Y, activeCursor->X + fontW - 1, activeCursor->Y + fontH - 1);
+	canvas->setBrushColor(textCursorActive() ? tbg : gbg);
+	canvas->fillRectangle(activeCursor->X, activeCursor->Y, activeCursor->X + fontW - 1, activeCursor->Y + fontH - 1);
 }
 
 // Set character overwrite mode (background fill)
 //
 inline void setCharacterOverwrite(bool overwrite) {
-	Canvas->setGlyphOptions(GlyphOptions().FillBackground(overwrite));
+	canvas->setGlyphOptions(GlyphOptions().FillBackground(overwrite));
 }
 
 // Set a clipping rectangle
 //
 void setClippingRect(Rect rect) {
-	Canvas->setClippingRect(rect);
+	canvas->setClippingRect(rect);
 }
 
 // Draw cursor
 //
 void drawCursor(Point p) {
-	Canvas->swapRectangle(p.X, p.Y, p.X + fontW - 1, p.Y + fontH - 1);
+	canvas->swapRectangle(p.X, p.Y, p.X + fontW - 1, p.Y + fontH - 1);
 }
 
 
@@ -357,10 +357,10 @@ void cls(bool resetViewports) {
 	if (resetViewports) {
 		viewportReset();
 	}
-	if (Canvas) {
-		Canvas->setPenColor(tfg);
-		Canvas->setBrushColor(tbg);	
-		Canvas->setPaintOptions(tpo);
+	if (canvas) {
+		canvas->setPenColor(tfg);
+		canvas->setBrushColor(tbg);	
+		canvas->setPaintOptions(tpo);
 		clearViewport(getViewport(VIEWPORT_TEXT));
 	}
 	if (hasActiveSprites()) {
@@ -374,10 +374,10 @@ void cls(bool resetViewports) {
 // Clear the graphics area
 //
 void clg() {
-	if (Canvas) {
-		Canvas->setPenColor(gfg);
-		Canvas->setBrushColor(gbg);	
-		Canvas->setPaintOptions(gpo);
+	if (canvas) {
+		canvas->setPenColor(gfg);
+		canvas->setBrushColor(gbg);	
+		canvas->setPaintOptions(gpo);
 		clearViewport(getViewport(VIEWPORT_GRAPHICS));
 	}
 	pushPoint(0, 0);		// Reset graphics origin (as per BBC Micro CLG)
@@ -538,16 +538,16 @@ int change_mode(int mode) {
 	gbg = colourLookup[0x00];
 	tfg = colourLookup[0x3F];
 	tbg = colourLookup[0x00];
-	Canvas->selectFont(&fabgl::FONT_AGON);
+	canvas->selectFont(&fabgl::FONT_AGON);
 	setCharacterOverwrite(true);
-	Canvas->setPenWidth(1);
+	canvas->setPenWidth(1);
 	setOrigin(0,0);
 	pushPoint(0,0);
 	pushPoint(0,0);
 	pushPoint(0,0);
-	setCanvasWH(Canvas->getWidth(), Canvas->getHeight());
-	fontW = Canvas->getFontInfo()->width;
-	fontH = Canvas->getFontInfo()->height;
+	setCanvasWH(canvas->getWidth(), canvas->getHeight());
+	fontW = canvas->getFontInfo()->width;
+	fontH = canvas->getFontInfo()->height;
 	viewportReset();
 	resetCursor();
 	homeCursor();
@@ -581,20 +581,20 @@ void setLegacyModes(bool legacy) {
 }
 
 void scrollRegion(Rect * region, int direction, int movement) {
-	Canvas->setScrollingRegion(region->X1, region->Y1, region->X2, region->Y2);
+	canvas->setScrollingRegion(region->X1, region->Y1, region->X2, region->Y2);
 
 	switch (direction) {
 		case 0:	// Right
-			Canvas->scroll(movement, 0);
+			canvas->scroll(movement, 0);
 			break;
 		case 1: // Left
-			Canvas->scroll(-movement, 0);
+			canvas->scroll(-movement, 0);
 			break;
 		case 2: // Down
-			Canvas->scroll(0, movement);
+			canvas->scroll(0, movement);
 			break;
 		case 3: // Up
-			Canvas->scroll(0, -movement);
+			canvas->scroll(0, -movement);
 			break;
 	}
 	waitPlotCompletion();

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -408,138 +408,132 @@ int change_mode(int mode) {
 	doubleBuffered = false;			// Default is to not double buffer the display
 
 	cls(true);
-	if (mode != videoMode) {
-		switch (mode) {
-			case 0:{
-					if (legacyModes == true) {
-						errVal = change_resolution(2, SVGA_1024x768_60Hz);
-					} else {
-						errVal = change_resolution(16, VGA_640x480_60Hz);	// VDP 1.03 Mode 3, VGA Mode 12h
-					}
-				}
-				break;
-			case 1:{
-					if (legacyModes == true) {
-						errVal = change_resolution(16, VGA_512x384_60Hz);
-					} else {
-						errVal = change_resolution(4, VGA_640x480_60Hz);
-					}
-				}
-				break;
-			case 2:{
-					if (legacyModes == true) {
-						errVal = change_resolution(64, VGA_320x200_75Hz);
-					} else {
-						errVal = change_resolution(2, VGA_640x480_60Hz);
-					}
-				}
-				break;
-			case 3: {
-					if (legacyModes == true) {
-						errVal = change_resolution(16, VGA_640x480_60Hz);
-					} else {
-						errVal = change_resolution(64, VGA_640x240_60Hz);
-					}
-				}
-				break;
-			case 4:
-				errVal = change_resolution(16, VGA_640x240_60Hz);
-				break;
-			case 5:
-				errVal = change_resolution(4, VGA_640x240_60Hz);
-				break;
-			case 6:
-				errVal = change_resolution(2, VGA_640x240_60Hz);
-				break;
-			case 8:
-				errVal = change_resolution(64, QVGA_320x240_60Hz);		// VGA "Mode X"
-				break;
-			case 9:
-				errVal = change_resolution(16, QVGA_320x240_60Hz);
-				break;
-			case 10:
-				errVal = change_resolution(4, QVGA_320x240_60Hz);
-				break;
-			case 11:
-				errVal = change_resolution(2, QVGA_320x240_60Hz);
-				break;
-			case 12:
-				errVal = change_resolution(64, VGA_320x200_70Hz);		// VGA Mode 13h
-				break;
-			case 13:
-				errVal = change_resolution(16, VGA_320x200_70Hz);
-				break;
-			case 14:
-				errVal = change_resolution(4, VGA_320x200_70Hz);
-				break;
-			case 15:
-				errVal = change_resolution(2, VGA_320x200_70Hz);
-				break;
-			case 16:
-				errVal = change_resolution(4, SVGA_800x600_60Hz);
-				break;
-			case 17:
-				errVal = change_resolution(2, SVGA_800x600_60Hz);
-				break;
-			case 18:
-				errVal = change_resolution(2, SVGA_1024x768_60Hz);		// VDP 1.03 Mode 0
-				break;
-			case 129:
-				doubleBuffered = true;
+	switch (mode) {
+		case 0:
+			if (legacyModes == true) {
+				errVal = change_resolution(2, SVGA_1024x768_60Hz);
+			} else {
+				errVal = change_resolution(16, VGA_640x480_60Hz);	// VDP 1.03 Mode 3, VGA Mode 12h
+			}
+			break;
+		case 1:
+			if (legacyModes == true) {
+				errVal = change_resolution(16, VGA_512x384_60Hz);
+			} else {
 				errVal = change_resolution(4, VGA_640x480_60Hz);
-				break;
-			case 130:
-				doubleBuffered = true;
+			}
+			break;
+		case 2:
+			if (legacyModes == true) {
+				errVal = change_resolution(64, VGA_320x200_75Hz);
+			} else {
 				errVal = change_resolution(2, VGA_640x480_60Hz);
-				break;
-			case 132:
-				doubleBuffered = true;
-				errVal = change_resolution(16, VGA_640x240_60Hz);
-				break;
-			case 133:
-				doubleBuffered = true;
-				errVal = change_resolution(4, VGA_640x240_60Hz);
-				break;
-			case 134:
-				doubleBuffered = true;
-				errVal = change_resolution(2, VGA_640x240_60Hz);
-				break;
-			case 136:
-				doubleBuffered = true;
-				errVal = change_resolution(64, QVGA_320x240_60Hz);		// VGA "Mode X"
-				break;
-			case 137:
-				doubleBuffered = true;
-				errVal = change_resolution(16, QVGA_320x240_60Hz);
-				break;
-			case 138:
-				doubleBuffered = true;
-				errVal = change_resolution(4, QVGA_320x240_60Hz);
-				break;	
-			case 139:
-				doubleBuffered = true;
-				errVal = change_resolution(2, QVGA_320x240_60Hz);
-				break;
-			case 140:
-				doubleBuffered = true;
-				errVal = change_resolution(64, VGA_320x200_70Hz);		// VGA Mode 13h
-				break;
-			case 141:
-				doubleBuffered = true;
-				errVal = change_resolution(16, VGA_320x200_70Hz);
-				break;
-			case 142:
-				doubleBuffered = true;
-				errVal = change_resolution(4, VGA_320x200_70Hz);
-				break;
-			case 143:
-				doubleBuffered = true;
-				errVal = change_resolution(2, VGA_320x200_70Hz);
-				break;									
-		}
-		if (errVal != 0) {
-			return errVal;
-		}
+			}
+			break;
+		case 3:
+			if (legacyModes == true) {
+				errVal = change_resolution(16, VGA_640x480_60Hz);
+			} else {
+				errVal = change_resolution(64, VGA_640x240_60Hz);
+			}
+			break;
+		case 4:
+			errVal = change_resolution(16, VGA_640x240_60Hz);
+			break;
+		case 5:
+			errVal = change_resolution(4, VGA_640x240_60Hz);
+			break;
+		case 6:
+			errVal = change_resolution(2, VGA_640x240_60Hz);
+			break;
+		case 8:
+			errVal = change_resolution(64, QVGA_320x240_60Hz);		// VGA "Mode X"
+			break;
+		case 9:
+			errVal = change_resolution(16, QVGA_320x240_60Hz);
+			break;
+		case 10:
+			errVal = change_resolution(4, QVGA_320x240_60Hz);
+			break;
+		case 11:
+			errVal = change_resolution(2, QVGA_320x240_60Hz);
+			break;
+		case 12:
+			errVal = change_resolution(64, VGA_320x200_70Hz);		// VGA Mode 13h
+			break;
+		case 13:
+			errVal = change_resolution(16, VGA_320x200_70Hz);
+			break;
+		case 14:
+			errVal = change_resolution(4, VGA_320x200_70Hz);
+			break;
+		case 15:
+			errVal = change_resolution(2, VGA_320x200_70Hz);
+			break;
+		case 16:
+			errVal = change_resolution(4, SVGA_800x600_60Hz);
+			break;
+		case 17:
+			errVal = change_resolution(2, SVGA_800x600_60Hz);
+			break;
+		case 18:
+			errVal = change_resolution(2, SVGA_1024x768_60Hz);		// VDP 1.03 Mode 0
+			break;
+		case 129:
+			doubleBuffered = true;
+			errVal = change_resolution(4, VGA_640x480_60Hz);
+			break;
+		case 130:
+			doubleBuffered = true;
+			errVal = change_resolution(2, VGA_640x480_60Hz);
+			break;
+		case 132:
+			doubleBuffered = true;
+			errVal = change_resolution(16, VGA_640x240_60Hz);
+			break;
+		case 133:
+			doubleBuffered = true;
+			errVal = change_resolution(4, VGA_640x240_60Hz);
+			break;
+		case 134:
+			doubleBuffered = true;
+			errVal = change_resolution(2, VGA_640x240_60Hz);
+			break;
+		case 136:
+			doubleBuffered = true;
+			errVal = change_resolution(64, QVGA_320x240_60Hz);		// VGA "Mode X"
+			break;
+		case 137:
+			doubleBuffered = true;
+			errVal = change_resolution(16, QVGA_320x240_60Hz);
+			break;
+		case 138:
+			doubleBuffered = true;
+			errVal = change_resolution(4, QVGA_320x240_60Hz);
+			break;	
+		case 139:
+			doubleBuffered = true;
+			errVal = change_resolution(2, QVGA_320x240_60Hz);
+			break;
+		case 140:
+			doubleBuffered = true;
+			errVal = change_resolution(64, VGA_320x200_70Hz);		// VGA Mode 13h
+			break;
+		case 141:
+			doubleBuffered = true;
+			errVal = change_resolution(16, VGA_320x200_70Hz);
+			break;
+		case 142:
+			doubleBuffered = true;
+			errVal = change_resolution(4, VGA_320x200_70Hz);
+			break;
+		case 143:
+			doubleBuffered = true;
+			errVal = change_resolution(2, VGA_320x200_70Hz);
+			break;									
+	}
+	if (errVal != 0) {
+		return errVal;
 	}
 	switch (getVGAColourDepth()) {
 		case  2: resetPalette(defaultPalette02); break;
@@ -564,8 +558,9 @@ int change_mode(int mode) {
 	setCanvasWH(Canvas->getWidth(), Canvas->getHeight());
 	fontW = Canvas->getFontInfo()->width;
 	fontH = Canvas->getFontInfo()->height;
-	resetCursor();
 	viewportReset();
+	resetCursor();
+	homeCursor();
 	sendModeInformation();
 	debug_log("do_modeChange: canvas(%d,%d), scale(%f,%f), mode %d, videoMode %d\n\r", canvasW, canvasH, logicalScaleX, logicalScaleY, mode, videoMode);
 	return 0;
@@ -580,7 +575,12 @@ void set_mode(int mode) {
 	int errVal = change_mode(mode);
 	if (errVal != 0) {
 		debug_log("set_mode: error %d\n\r", errVal);
-		change_mode(videoMode);
+		errVal = change_mode(videoMode);
+		if (errVal != 0) {
+			debug_log("set_mode: error %d on restoring mode\n\r", errVal);
+			videoMode = 1;
+			change_mode(1);
+		}
 		return;
 	}
 	videoMode = mode;

--- a/video/sprites.h
+++ b/video/sprites.h
@@ -1,0 +1,153 @@
+#ifndef SPRITES_H
+#define SPRITES_H
+
+#include <Arduino.h>
+#include <fabgl.h>
+
+#include "agon.h"
+#include "agon_screen.h"
+
+uint8_t			numsprites = 0;					// Number of sprites on stage
+uint8_t			current_sprite = 0;				// Current sprite number
+uint8_t			current_bitmap = 0;				// Current bitmap number
+Bitmap			bitmaps[MAX_BITMAPS];			// Bitmap object storage
+Sprite			sprites[MAX_SPRITES];			// Sprite object storage
+
+Bitmap * getBitmap(uint8_t b = current_bitmap) {
+	return &bitmaps[b];
+}
+
+void setCurrentBitmap(uint8_t b) {
+	current_bitmap = b;
+}
+
+inline uint8_t getCurrentBitmap() {
+	return current_bitmap;
+}
+
+void clearBitmap(uint8_t b = current_bitmap) {
+	auto bitmap = getBitmap(b);
+	if (bitmap->data) {
+		free(bitmap->data);
+		bitmap->data = nullptr;
+	}
+	bitmap->dataAllocated = false;
+}
+
+void createBitmap(int width, int height, void * data, PixelFormat format = PixelFormat::RGBA8888) {
+	clearBitmap();
+	bitmaps[current_bitmap] = Bitmap(width, height, (uint8_t *)data, format);
+	bitmaps[current_bitmap].dataAllocated = false;
+}
+
+void drawBitmap(int x, int y) {
+	auto bitmap = getBitmap();
+	if (bitmap->data) {
+		Canvas->drawBitmap(x, y, bitmap);
+		waitPlotCompletion();
+	}
+}
+
+void resetBitmaps() {
+	for (int n = 0; n < MAX_BITMAPS; n++) {
+		clearBitmap(n);
+	}
+	waitPlotCompletion();
+}
+
+Sprite * getSprite(uint8_t sprite = current_sprite) {
+	return &sprites[sprite];
+}
+
+void setCurrentSprite(uint8_t s) {
+	current_sprite = s;
+}
+
+inline uint8_t getCurrentSprite() {
+	return current_sprite;
+}
+
+void clearSpriteFrames(uint8_t s = current_sprite) {
+	auto sprite = getSprite(s);
+	sprite->visible = false;
+	sprite->setFrame(0);
+	sprite->clearBitmaps();
+}
+
+void addSpriteFrame(uint8_t bitmap) {
+	auto sprite = getSprite();
+	sprite->addBitmap(getBitmap(bitmap));
+}
+
+void activateSprites(uint8_t n) {
+	/*
+	* Sprites 0-(numsprites-1) will be activated on-screen
+	* Make sure all sprites have at least one frame attached to them
+	*/
+	numsprites = n;
+	auto controller = getVGAController();
+
+	if (numsprites) {
+		controller->setSprites(sprites, numsprites);
+	} else {
+		controller->removeSprites();
+	}
+	waitPlotCompletion();
+}
+
+bool hasActiveSprites() {
+	return numsprites > 0;
+}
+
+void nextSpriteFrame() {
+	auto sprite = getSprite();
+	sprite->nextFrame();
+}
+
+void previousSpriteFrame() {
+	auto sprite = getSprite();
+	auto frame = sprite->currentFrame;
+	sprite->setFrame(frame ? frame - 1 : sprite->framesCount - 1);
+}
+
+void setSpriteFrame(uint8_t n) {
+	auto sprite = getSprite();
+	if (n < sprite->framesCount) {
+		sprite->setFrame(n);
+	}
+}
+
+void showSprite() {
+	auto sprite = getSprite();
+	sprite->visible = 1;
+}
+
+void hideSprite() {
+	auto sprite = getSprite();
+	sprite->visible = 0;
+}
+
+void moveSprite(int x, int y) {
+	auto sprite = getSprite();
+	sprite->moveTo(x, y);
+}
+
+void moveSpriteBy(int x, int y) {
+	auto sprite = getSprite();
+	sprite->moveBy(x, y);
+}
+
+void refreshSprites() {
+	if (numsprites) {
+		VGAController->refreshSprites();
+	}
+}
+
+void resetSprites() {
+	for (int n = 0; n < MAX_SPRITES; n++) {
+		clearSpriteFrames(n);
+	}
+	waitPlotCompletion();
+}
+
+#endif // SPRITES_H

--- a/video/sprites.h
+++ b/video/sprites.h
@@ -43,7 +43,7 @@ void createBitmap(int width, int height, void * data, PixelFormat format = Pixel
 void drawBitmap(int x, int y) {
 	auto bitmap = getBitmap();
 	if (bitmap->data) {
-		Canvas->drawBitmap(x, y, bitmap);
+		canvas->drawBitmap(x, y, bitmap);
 		waitPlotCompletion();
 	}
 }
@@ -139,7 +139,7 @@ void moveSpriteBy(int x, int y) {
 
 void refreshSprites() {
 	if (numsprites) {
-		VGAController->refreshSprites();
+		getVGAController()->refreshSprites();
 	}
 }
 

--- a/video/vdp_protocol.h
+++ b/video/vdp_protocol.h
@@ -1,0 +1,118 @@
+//
+// Title:			Agon Video BIOS
+// Author:			Dean Belfield
+// Contributors:	Steve Sims (refactoring)
+// Created:			25/08/2023
+// Last Updated:	25/08/2023
+//
+
+#ifndef AGON_VDP_PROTOCOL_H
+#define AGON_VDP_PROTOCOL_H
+
+#include <memory>
+#include <HardwareSerial.h>
+
+#include "agon.h"								// Configuration file
+
+#define VDPSerial Serial2
+
+#pragma once
+
+void setupVDPProtocol() {
+	VDPSerial.end();
+	VDPSerial.setRxBufferSize(UART_RX_SIZE);					// Can't be called when running
+	VDPSerial.begin(UART_BR, SERIAL_8N1, UART_RX, UART_TX);
+	VDPSerial.setHwFlowCtrlMode(HW_FLOWCTRL_RTS, 64);			// Can be called whenever
+	VDPSerial.setPins(UART_NA, UART_NA, UART_CTS, UART_RTS);	// Must be called after begin
+}
+
+inline bool byteAvailable() {
+	return VDPSerial.available() > 0;
+}
+
+inline byte readByte() {
+	return VDPSerial.read();
+}
+
+inline void writeByte(byte b) {
+	VDPSerial.write(b);
+}
+
+// Read an unsigned byte from the serial port, with a timeout
+// Returns:
+// - Byte value (0 to 255) if value read, otherwise -1
+//
+int readByte_t() {
+	int	i;
+	unsigned long t = millis();
+
+	while (millis() - t < 1000) {
+		if (byteAvailable()) {
+			return readByte();
+		}
+	}
+	return -1;
+}
+
+// Read an unsigned word from the serial port, with a timeout
+// Returns:
+// - Word value (0 to 65535) if 2 bytes read, otherwise -1
+//
+int	readWord_t() {
+	int	l = readByte_t();
+	if (l >= 0) {
+		int h = readByte_t();
+		if (h >= 0) {
+			return (h << 8) | l;
+		}
+	}
+	return -1;
+}
+
+// Read an unsigned 24-bit value from the serial port, with a timeout
+// Returns:
+// - Value (0 to 16777215) if 3 bytes read, otherwise -1
+//
+int	read24_t() {
+	int	l = readByte_t();
+	if (l >= 0) {
+		int m = readByte_t();
+		if (m >= 0) {
+			int h = readByte_t();
+			if (h >= 0) {
+				return (h << 16) | (m << 8) | l;
+			}
+		}
+	}
+	return -1;
+}
+
+// Read an unsigned byte from the serial port (blocking)
+//
+byte readByte_b() {
+  	while (VDPSerial.available() == 0);
+  	return readByte();
+}
+
+// Read an unsigned word from the serial port (blocking)
+//
+uint32_t readLong_b() {
+  uint32_t temp;
+  temp  =  readByte_b();		// LSB;
+  temp |= (readByte_b() << 8);
+  temp |= (readByte_b() << 16);
+  temp |= (readByte_b() << 24);
+  return temp;
+}
+
+// Send a packet of data to the MOS
+//
+void send_packet(byte code, byte len, byte data[]) {
+	writeByte(code + 0x80);
+	writeByte(len);
+	for (int i = 0; i < len; i++) {
+		writeByte(data[i]);
+	}
+}
+
+#endif // AGON_VDP_PROTOCOL_H

--- a/video/vdp_protocol.h
+++ b/video/vdp_protocol.h
@@ -105,6 +105,15 @@ uint32_t readLong_b() {
   return temp;
 }
 
+// Discard a given number of bytes from input stream
+//
+void discardBytes(int length) {
+	while (length > 0) {
+		readByte_b();
+		length--;
+	}
+}
+
 // Send a packet of data to the MOS
 //
 void send_packet(byte code, byte len, byte data[]) {

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -148,8 +148,6 @@ void vdu_cursorTab() {
 // Handle VDU commands
 //
 void vdu(byte c) {
-	bool useTextCursor = (activeCursor == &textCursor);
-
 	switch(c) {
 		case 0x04:	
 			// enable text cursor

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -11,7 +11,7 @@
 void vdu_colour() {
 	int		colour = readByte_t();
 
-    setTextColour(colour);
+	setTextColour(colour);
 }
 
 // VDU 18 Handle GCOL
@@ -20,7 +20,7 @@ void vdu_gcol() {
 	int		mode = readByte_t();
 	int		colour = readByte_t();
 
-    setGraphicsColour(mode, colour);
+	setGraphicsColour(mode, colour);
 }
 
 // VDU 19 Handle palette
@@ -32,13 +32,13 @@ void vdu_palette() {
 	int g = readByte_t(); if (g == -1) return; // The green component
 	int b = readByte_t(); if (b == -1) return; // The blue component
 
-    setPalette(l, p, r, g, b);
+	setPalette(l, p, r, g, b);
 }
 
 // VDU 22 Handle MODE
 //
 void vdu_mode() {
-  	int mode = readByte_t();
+	int mode = readByte_t();
 	debug_log("vdu_mode: %d\n\r", mode);
 	if (mode >= 0) {
 	  	set_mode(mode);
@@ -64,32 +64,32 @@ void vdu_graphicsViewport() {
 // VDU 25 Handle PLOT
 //
 void vdu_plot() {
-  	int mode = readByte_t(); if (mode == -1) return;
+	int mode = readByte_t(); if (mode == -1) return;
 
 	int x = readWord_t(); if (x == -1) return; else x = (short)x;
 	int y = readWord_t(); if (y == -1) return; else y = (short)y;
 
-    pushPoint(x, y);
-    setGraphicsOptions();
+	pushPoint(x, y);
+	setGraphicsOptions();
 
 	debug_log("vdu_plot: mode %d, (%d,%d) -> (%d,%d)\n\r", mode, x, y, p1.X, p1.Y);
   	switch (mode) {
-    	case 0x04: 			// Move
-            moveTo();
-      		break;
-    	case 0x05: 			// Line
-            plotLine();
-      		break;
+		case 0x04: 			// Move
+			moveTo();
+			break;
+		case 0x05: 			// Line
+			plotLine();
+			break;
 		case 0x40 ... 0x47:	// Point
 			plotPoint();
 			break;
-    	case 0x50 ... 0x57: // Triangle
-      		plotTriangle(mode - 0x50);
-      		break;
-    	case 0x90 ... 0x97: // Circle
-            plotCircle(mode - 0x90);
-      		break;
-  	}
+		case 0x50 ... 0x57: // Triangle
+			plotTriangle(mode - 0x50);
+			break;
+		case 0x90 ... 0x97: // Circle
+			plotCircle(mode - 0x90);
+			break;
+	}
 	waitPlotCompletion();
 }
 
@@ -97,7 +97,9 @@ void vdu_plot() {
 //
 void vdu_resetViewports() {
 	viewportReset();
-    // TODO reset cursors too (according to BBC BASIC manual)
+	// reset cursors too (according to BBC BASIC manual)
+	cursorHome();
+	pushPoint(0, 0);
 	debug_log("vdu_resetViewport\n\r");
 }
 
@@ -138,7 +140,7 @@ void vdu_cursorTab() {
 	if (x >= 0) {
 		int y = readByte_t();
 		if (y >= 0) {
-            cursorTab(x, y);
+			cursorTab(x, y);
 		}
 	}
 }
@@ -148,90 +150,90 @@ void vdu_cursorTab() {
 void vdu(byte c) {
 	bool useTextCursor = (activeCursor == &textCursor);
 
-    switch(c) {
-        case 0x04:	
-            // enable text cursor
-            setCharacterOverwrite(true);
-            setActiveCursor(getTextCursor());
-            setActiveViewport(VIEWPORT_TEXT);
-            break;
-        case 0x05:
-            // enable graphics cursor
-            setCharacterOverwrite(false);
-            setActiveCursor(getGraphicsCursor());
-            setActiveViewport(VIEWPORT_GRAPHICS);
-            break;
-        case 0x07:	// Bell
-            play_note(0, 100, 750, 125);
-            break;
-        case 0x08:  // Cursor Left
-            cursorLeft();
-            break;
-        case 0x09:  // Cursor Right
-            cursorRight();
-            break;
-        case 0x0A:  // Cursor Down
-            cursorDown();
-            break;
-        case 0x0B:  // Cursor Up
-            cursorUp();
-            break;
-        case 0x0C:  // CLS
-            cls(false);
-            break;
-        case 0x0D:  // CR
-            cursorCR();
-            break;
-        case 0x0E:	// Paged mode ON
-            setPagedMode(true);
-            break;
-        case 0x0F:	// Paged mode OFF
-            setPagedMode(false);
-            break;
-        case 0x10:	// CLG
-            clg();
-            break;
-        case 0x11:	// COLOUR
-            vdu_colour();
-            break;
-        case 0x12:  // GCOL
-            vdu_gcol();
-            break;
-        case 0x13:	// Define Logical Colour
-            vdu_palette();
-            break;
-        case 0x16:  // Mode
-            vdu_mode();
-            break;
-        case 0x17:  // VDU 23
-            vdu_sys();
-            break;
-        case 0x18:	// Define a graphics viewport
-            vdu_graphicsViewport();
-            break;
-        case 0x19:  // PLOT
-            vdu_plot();
-            break;
-        case 0x1A:	// Reset text and graphics viewports
-            vdu_resetViewports();
-            break;
-        case 0x1C:	// Define a text viewport
-            vdu_textViewport();
-            break;
-        case 0x1D:	// VDU_29
-            vdu_origin();
-        case 0x1E:	// Move cursor to top left of the viewport
-            cursorHome();
-            break;
-        case 0x1F:	// TAB(X,Y)
-            vdu_cursorTab();
-            break;
-        case 0x20 ... 0x7E:
-        case 0x80 ... 0xFF:
-            plotCharacter(c);
-            break;
-        case 0x7F:  // Backspace
-            plotBackspace();
-            break;
-    }
+	switch(c) {
+		case 0x04:	
+			// enable text cursor
+			setCharacterOverwrite(true);
+			setActiveCursor(getTextCursor());
+			setActiveViewport(VIEWPORT_TEXT);
+			break;
+		case 0x05:
+			// enable graphics cursor
+			setCharacterOverwrite(false);
+			setActiveCursor(getGraphicsCursor());
+			setActiveViewport(VIEWPORT_GRAPHICS);
+			break;
+		case 0x07:	// Bell
+			play_note(0, 100, 750, 125);
+			break;
+		case 0x08:  // Cursor Left
+			cursorLeft();
+			break;
+		case 0x09:  // Cursor Right
+			cursorRight();
+			break;
+		case 0x0A:  // Cursor Down
+			cursorDown();
+			break;
+		case 0x0B:  // Cursor Up
+			cursorUp();
+			break;
+		case 0x0C:  // CLS
+			cls(false);
+			break;
+		case 0x0D:  // CR
+			cursorCR();
+			break;
+		case 0x0E:	// Paged mode ON
+			setPagedMode(true);
+			break;
+		case 0x0F:	// Paged mode OFF
+			setPagedMode(false);
+			break;
+		case 0x10:	// CLG
+			clg();
+			break;
+		case 0x11:	// COLOUR
+			vdu_colour();
+			break;
+		case 0x12:  // GCOL
+			vdu_gcol();
+			break;
+		case 0x13:	// Define Logical Colour
+			vdu_palette();
+			break;
+		case 0x16:  // Mode
+			vdu_mode();
+			break;
+		case 0x17:  // VDU 23
+			vdu_sys();
+			break;
+		case 0x18:	// Define a graphics viewport
+			vdu_graphicsViewport();
+			break;
+		case 0x19:  // PLOT
+			vdu_plot();
+			break;
+		case 0x1A:	// Reset text and graphics viewports
+			vdu_resetViewports();
+			break;
+		case 0x1C:	// Define a text viewport
+			vdu_textViewport();
+			break;
+		case 0x1D:	// VDU_29
+			vdu_origin();
+		case 0x1E:	// Move cursor to top left of the viewport
+			cursorHome();
+			break;
+		case 0x1F:	// TAB(X,Y)
+			vdu_cursorTab();
+			break;
+		case 0x20 ... 0x7E:
+		case 0x80 ... 0xFF:
+			plotCharacter(c);
+			break;
+		case 0x7F:  // Backspace
+			plotBackspace();
+			break;
+	}
 }

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -1,0 +1,368 @@
+#include <Arduino.h>
+
+#include "agon.h"
+#include "cursor.h"
+#include "vdu_sys.h"
+
+extern void cls(bool resetViewports);
+extern void clg();
+extern void set_mode(int mode);
+extern bool doWaitCompletion;
+
+// TODO move to graphics handler file:
+
+// Get the paint options for a given GCOL mode
+//
+fabgl::PaintOptions getPaintOptions(int mode, fabgl::PaintOptions priorPaintOptions) {
+	fabgl::PaintOptions p = priorPaintOptions;
+	
+	switch(mode) {
+		case 0: p.NOT = 0; p.swapFGBG = 0; break;
+		case 4: p.NOT = 1; p.swapFGBG = 0; break;
+	}
+	return p;
+}
+
+// Set a palette item
+// Parameters:
+// - l: The logical colour to change
+// - c: The new colour
+// 
+void setPaletteItem(int l, RGB888 c) {
+	if(l < VGAColourDepth) {
+		switch(VGAColourDepth) {
+			case 2: VGAController2.setPaletteItem(l, c); break;
+			case 4: VGAController4.setPaletteItem(l, c); break;
+			case 8: VGAController8.setPaletteItem(l, c); break;
+			case 16: VGAController16.setPaletteItem(l, c); break;
+		}
+	}
+}
+
+
+
+// VDU 17 Handle COLOUR
+// 
+void vdu_colour() {
+	int		colour = readByte_t();
+	byte	c = palette[colour%VGAColourDepth];
+
+	if(colour >= 0 && colour < 64) {
+		tfg = colourLookup[c];
+		debug_log("vdu_colour: tfg %d = %02X : %02X,%02X,%02X\n\r", colour, c, tfg.R, tfg.G, tfg.B);
+	}
+	else if(colour >= 128 && colour < 192) {
+		tbg = colourLookup[c];
+		debug_log("vdu_colour: tbg %d = %02X : %02X,%02X,%02X\n\r", colour, c, tbg.R, tbg.G, tbg.B);	
+	}
+	else {
+		debug_log("vdu_colour: invalid colour %d\n\r", colour);
+	}
+}
+
+// VDU 18 Handle GCOL
+// 
+void vdu_gcol() {
+	int		mode = readByte_t();
+	int		colour = readByte_t();
+	
+	byte	c = palette[colour%VGAColourDepth];
+
+	if(mode >= 0 && mode <= 6) {
+		if(colour >= 0 && colour < 64) {
+			gfg = colourLookup[c];
+			debug_log("vdu_gcol: mode %d, gfg %d = %02X : %02X,%02X,%02X\n\r", mode, colour, c, gfg.R, gfg.G, gfg.B);
+		}
+		else if(colour >= 128 && colour < 192) {
+			gbg = colourLookup[c];
+			debug_log("vdu_gcol: mode %d, gbg %d = %02X : %02X,%02X,%02X\n\r", mode, colour, c, gbg.R, gbg.G, gbg.B);
+		}
+		else {
+			debug_log("vdu_gcol: invalid colour %d\n\r", colour);
+		}
+		gpo = getPaintOptions(mode, gpo);
+	}
+	else {
+		debug_log("vdu_gcol: invalid mode %d\n\r", mode);
+	}
+}
+
+// VDU 19 Handle palette
+//
+void vdu_palette() {
+	int l = readByte_t(); if(l == -1) return; // Logical colour
+	int p = readByte_t(); if(p == -1) return; // Physical colour
+	int r = readByte_t(); if(r == -1) return; // The red component
+	int g = readByte_t(); if(g == -1) return; // The green component
+	int b = readByte_t(); if(b == -1) return; // The blue component
+
+	RGB888 col;				// The colour to set
+
+	if(VGAColourDepth < 64) {			// If it is a paletted video mode
+		if(p == 255) {					// If p = 255, then use the RGB values
+			col = RGB888(r, g, b);
+		}
+		else if(p < 64) {				// If p < 64, then look the value up in the colour lookup table
+			col = colourLookup[p];
+		}
+		else {				
+			debug_log("vdu_palette: p=%d not supported\n\r", p);
+			return;
+		}
+		setPaletteItem(l, col);
+		doWaitCompletion = true;
+		debug_log("vdu_palette: %d,%d,%d,%d,%d\n\r", l, p, r, g, b);
+	}
+	else {
+		debug_log("vdu_palette: not supported in this mode\n\r");
+	}
+}
+
+// VDU 22 Handle MODE
+//
+void vdu_mode() {
+  	int mode = readByte_t();
+	debug_log("vdu_mode: %d\n\r", mode);
+	if(mode >= 0) {
+	  	set_mode(mode);
+	}
+}
+
+// VDU 24 Graphics viewport
+// Example: VDU 24,640;256;1152;896;
+//
+void vdu_graphicsViewport() {
+	int x1 = readWord_t();			// Left
+	int y2 = readWord_t();			// Bottom
+	int x2 = readWord_t();			// Right
+	int y1 = readWord_t();			// Top
+
+	if (setGraphicsViewport(x1, y1, x2, y2)) {
+		debug_log("vdu_graphicsViewport: OK %d,%d,%d,%d\n\r", p1.X, p1.Y, p2.X, p2.Y);
+	} else {
+		debug_log("vdu_graphicsViewport: Invalid Viewport %d,%d,%d,%d\n\r", p1.X, p1.Y, p2.X, p2.Y);
+	}
+}
+
+void vdu_plot_triangle(byte mode) {
+  	Point p[3] = {
+		p3,
+		p2,
+		p1, 
+	};
+  	Canvas->setBrushColor(gfg);
+  	Canvas->fillPath(p, 3);
+  	Canvas->setBrushColor(tbg);
+}
+
+void vdu_plot_circle(byte mode) {
+  	int a, b, r;
+  	switch(mode) {
+    	case 0x90 ... 0x93: // Circle
+      		r = 2 * (p1.X + p1.Y);
+      		Canvas->drawEllipse(p2.X, p2.Y, r, r);
+      		break;
+    	case 0x94 ... 0x97: // Circle
+      		a = p2.X - p1.X;
+      		b = p2.Y - p1.Y;
+      		r = 2 * sqrt(a * a + b * b);
+      		Canvas->drawEllipse(p2.X, p2.Y, r, r);
+      		break;
+  	}
+}
+
+// VDU 25 Handle PLOT
+//
+void vdu_plot() {
+  	int mode = readByte_t(); if(mode == -1) return;
+
+	int x = readWord_t(); if(x == -1) return; else x = (short)x;
+	int y = readWord_t(); if(y == -1) return; else y = (short)y;
+
+  	p3 = p2;
+  	p2 = p1;
+	p1 = translateViewport(scale(x, y));
+	Canvas->setClippingRect(graphicsViewport);
+	Canvas->setPenColor(gfg);
+	Canvas->setPaintOptions(gpo);
+	debug_log("vdu_plot: mode %d, (%d,%d) -> (%d,%d)\n\r", mode, x, y, p1.X, p1.Y);
+  	switch(mode) {
+    	case 0x04: 			// Move 
+      		Canvas->moveTo(p1.X, p1.Y);
+      		break;
+    	case 0x05: 			// Line
+      		Canvas->lineTo(p1.X, p1.Y);
+      		break;
+		case 0x40 ... 0x47:	// Point
+			Canvas->setPixel(p1.X, p1.Y);
+			break;
+    	case 0x50 ... 0x57: // Triangle
+      		vdu_plot_triangle(mode);
+      		break;
+    	case 0x90 ... 0x97: // Circle
+      		vdu_plot_circle(mode);
+      		break;
+  	}
+	doWaitCompletion = true;
+}
+
+// VDU 26 Reset graphics and text viewports
+//
+void vdu_resetViewports() {
+	viewportReset();
+    // TODO reset cursors too (according to BBC BASIC manual)
+	debug_log("vdu_resetViewport\n\r");
+}
+
+// VDU 28: text viewport
+// Example: VDU 28,20,23,34,4
+//
+void vdu_textViewport() {
+	int x1 = readByte_t() * fontW;				// Left
+	int y2 = (readByte_t() + 1) * fontH - 1;	// Bottom
+	int x2 = (readByte_t() + 1) * fontW - 1;	// Right
+	int y1 = readByte_t() * fontH;				// Top
+
+	if (setTextViewport(x1, y1, x2, y2)) {
+		ensureCursorInViewport(textViewport);
+		debug_log("vdu_textViewport: OK %d,%d,%d,%d\n\r", x1, y1, x2, y2);
+	} else {
+		debug_log("vdu_textViewport: Invalid Viewport %d,%d,%d,%d\n\r", x1, y1, x2, y2);
+	}
+}
+
+// Handle VDU 29
+//
+void vdu_origin() {
+	int x = readWord_t();
+	if(x >= 0) {
+		int y = readWord_t();
+		if(y >= 0) {
+			setOrigin(x, y);
+			debug_log("vdu_origin: %d,%d\n\r", x, y);
+		}
+	}
+}
+
+// VDU 30 TAB(x,y)
+//
+void vdu_cursorTab() {
+	int x = readByte_t();
+	if (x >= 0) {
+		int y = readByte_t();
+		if (y >= 0) {
+            cursorTab(x, y);
+		}
+	}
+}
+
+// Handle VDU commands
+//
+void vdu(byte c) {
+	bool useTextCursor = (activeCursor == &textCursor);
+
+    doWaitCompletion = false;
+    switch(c) {
+        case 0x04:	
+            // enable text cursor
+            Canvas->setGlyphOptions(GlyphOptions().FillBackground(true));
+            activeCursor = &textCursor;
+            activeViewport = &textViewport;
+            break;
+        case 0x05:
+            // enable graphics cursor
+            Canvas->setGlyphOptions(GlyphOptions().FillBackground(false));
+            activeCursor = &p1;
+            activeViewport = &graphicsViewport;
+            break;
+        case 0x07:	// Bell
+            play_note(0, 100, 750, 125);
+            break;
+        case 0x08:  // Cursor Left
+            cursorLeft();
+            break;
+        case 0x09:  // Cursor Right
+            cursorRight();
+            break;
+        case 0x0A:  // Cursor Down
+            cursorDown();
+            break;
+        case 0x0B:  // Cursor Up
+            cursorUp();
+            break;
+        case 0x0C:  // CLS
+            cls(false);
+            break;
+        case 0x0D:  // CR
+            cursorCR();
+            break;
+        case 0x0E:	// Paged mode ON
+            setPagedMode(true);
+            break;
+        case 0x0F:	// Paged mode OFF
+            setPagedMode(false);
+            break;
+        case 0x10:	// CLG
+            clg();
+            break;
+        case 0x11:	// COLOUR
+            vdu_colour();
+            break;
+        case 0x12:  // GCOL
+            vdu_gcol();
+            break;
+        case 0x13:	// Define Logical Colour
+            vdu_palette();
+            break;
+        case 0x16:  // Mode
+            vdu_mode();
+            break;
+        case 0x17:  // VDU 23
+            vdu_sys();
+            break;
+        case 0x18:	// Define a graphics viewport
+            vdu_graphicsViewport();
+            break;
+        case 0x19:  // PLOT
+            vdu_plot();
+            break;
+        case 0x1A:	// Reset text and graphics viewports
+            vdu_resetViewports();
+            break;
+        case 0x1C:	// Define a text viewport
+            vdu_textViewport();
+            break;
+        case 0x1D:	// VDU_29
+            vdu_origin();
+        case 0x1E:	// Move cursor to top left of the viewport
+            cursorHome();
+            break;
+        case 0x1F:	// TAB(X,Y)
+            vdu_cursorTab();
+            break;
+        case 0x20 ... 0x7E:
+        case 0x80 ... 0xFF:
+            if (useTextCursor) {
+                Canvas->setClippingRect(defaultViewport);
+                Canvas->setPenColor(tfg);
+                Canvas->setBrushColor(tbg);
+                Canvas->setPaintOptions(tpo);
+            }
+            else {
+                Canvas->setClippingRect(graphicsViewport);
+                Canvas->setPenColor(gfg);
+                Canvas->setPaintOptions(gpo);
+            }
+            Canvas->drawChar(activeCursor->X, activeCursor->Y, c);
+            cursorRight();
+            break;
+        case 0x7F:  // Backspace
+            cursorLeft();
+            Canvas->setBrushColor(useTextCursor ? tbg : gbg);
+            Canvas->fillRectangle(activeCursor->X, activeCursor->Y, activeCursor->X + fontW - 1, activeCursor->Y + fontH - 1);
+            break;
+    }
+    if (doWaitCompletion) {
+        Canvas->waitCompletion(false);
+    }
+}

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -2,62 +2,16 @@
 
 #include "agon.h"
 #include "cursor.h"
+#include "graphics.h"
 #include "vdu_sys.h"
-
-extern void cls(bool resetViewports);
-extern void clg();
-extern void set_mode(int mode);
-extern bool doWaitCompletion;
-
-// TODO move to graphics handler file:
-
-// Get the paint options for a given GCOL mode
-//
-fabgl::PaintOptions getPaintOptions(int mode, fabgl::PaintOptions priorPaintOptions) {
-	fabgl::PaintOptions p = priorPaintOptions;
-	
-	switch(mode) {
-		case 0: p.NOT = 0; p.swapFGBG = 0; break;
-		case 4: p.NOT = 1; p.swapFGBG = 0; break;
-	}
-	return p;
-}
-
-// Set a palette item
-// Parameters:
-// - l: The logical colour to change
-// - c: The new colour
-// 
-void setPaletteItem(int l, RGB888 c) {
-	if(l < VGAColourDepth) {
-		switch(VGAColourDepth) {
-			case 2: VGAController2.setPaletteItem(l, c); break;
-			case 4: VGAController4.setPaletteItem(l, c); break;
-			case 8: VGAController8.setPaletteItem(l, c); break;
-			case 16: VGAController16.setPaletteItem(l, c); break;
-		}
-	}
-}
-
 
 
 // VDU 17 Handle COLOUR
 // 
 void vdu_colour() {
 	int		colour = readByte_t();
-	byte	c = palette[colour%VGAColourDepth];
 
-	if(colour >= 0 && colour < 64) {
-		tfg = colourLookup[c];
-		debug_log("vdu_colour: tfg %d = %02X : %02X,%02X,%02X\n\r", colour, c, tfg.R, tfg.G, tfg.B);
-	}
-	else if(colour >= 128 && colour < 192) {
-		tbg = colourLookup[c];
-		debug_log("vdu_colour: tbg %d = %02X : %02X,%02X,%02X\n\r", colour, c, tbg.R, tbg.G, tbg.B);	
-	}
-	else {
-		debug_log("vdu_colour: invalid colour %d\n\r", colour);
-	}
+    setTextColour(colour);
 }
 
 // VDU 18 Handle GCOL
@@ -65,57 +19,20 @@ void vdu_colour() {
 void vdu_gcol() {
 	int		mode = readByte_t();
 	int		colour = readByte_t();
-	
-	byte	c = palette[colour%VGAColourDepth];
 
-	if(mode >= 0 && mode <= 6) {
-		if(colour >= 0 && colour < 64) {
-			gfg = colourLookup[c];
-			debug_log("vdu_gcol: mode %d, gfg %d = %02X : %02X,%02X,%02X\n\r", mode, colour, c, gfg.R, gfg.G, gfg.B);
-		}
-		else if(colour >= 128 && colour < 192) {
-			gbg = colourLookup[c];
-			debug_log("vdu_gcol: mode %d, gbg %d = %02X : %02X,%02X,%02X\n\r", mode, colour, c, gbg.R, gbg.G, gbg.B);
-		}
-		else {
-			debug_log("vdu_gcol: invalid colour %d\n\r", colour);
-		}
-		gpo = getPaintOptions(mode, gpo);
-	}
-	else {
-		debug_log("vdu_gcol: invalid mode %d\n\r", mode);
-	}
+    setGraphicsColour(mode, colour);
 }
 
 // VDU 19 Handle palette
 //
 void vdu_palette() {
-	int l = readByte_t(); if(l == -1) return; // Logical colour
-	int p = readByte_t(); if(p == -1) return; // Physical colour
-	int r = readByte_t(); if(r == -1) return; // The red component
-	int g = readByte_t(); if(g == -1) return; // The green component
-	int b = readByte_t(); if(b == -1) return; // The blue component
+	int l = readByte_t(); if (l == -1) return; // Logical colour
+	int p = readByte_t(); if (p == -1) return; // Physical colour
+	int r = readByte_t(); if (r == -1) return; // The red component
+	int g = readByte_t(); if (g == -1) return; // The green component
+	int b = readByte_t(); if (b == -1) return; // The blue component
 
-	RGB888 col;				// The colour to set
-
-	if(VGAColourDepth < 64) {			// If it is a paletted video mode
-		if(p == 255) {					// If p = 255, then use the RGB values
-			col = RGB888(r, g, b);
-		}
-		else if(p < 64) {				// If p < 64, then look the value up in the colour lookup table
-			col = colourLookup[p];
-		}
-		else {				
-			debug_log("vdu_palette: p=%d not supported\n\r", p);
-			return;
-		}
-		setPaletteItem(l, col);
-		doWaitCompletion = true;
-		debug_log("vdu_palette: %d,%d,%d,%d,%d\n\r", l, p, r, g, b);
-	}
-	else {
-		debug_log("vdu_palette: not supported in this mode\n\r");
-	}
+    setPalette(l, p, r, g, b);
 }
 
 // VDU 22 Handle MODE
@@ -123,7 +40,7 @@ void vdu_palette() {
 void vdu_mode() {
   	int mode = readByte_t();
 	debug_log("vdu_mode: %d\n\r", mode);
-	if(mode >= 0) {
+	if (mode >= 0) {
 	  	set_mode(mode);
 	}
 }
@@ -138,72 +55,42 @@ void vdu_graphicsViewport() {
 	int y1 = readWord_t();			// Top
 
 	if (setGraphicsViewport(x1, y1, x2, y2)) {
-		debug_log("vdu_graphicsViewport: OK %d,%d,%d,%d\n\r", p1.X, p1.Y, p2.X, p2.Y);
+		debug_log("vdu_graphicsViewport: OK %d,%d,%d,%d\n\r", x1, y1, x2, y2);
 	} else {
-		debug_log("vdu_graphicsViewport: Invalid Viewport %d,%d,%d,%d\n\r", p1.X, p1.Y, p2.X, p2.Y);
+		debug_log("vdu_graphicsViewport: Invalid Viewport %d,%d,%d,%d\n\r", x1, y1, x2, y2);
 	}
-}
-
-void vdu_plot_triangle(byte mode) {
-  	Point p[3] = {
-		p3,
-		p2,
-		p1, 
-	};
-  	Canvas->setBrushColor(gfg);
-  	Canvas->fillPath(p, 3);
-  	Canvas->setBrushColor(tbg);
-}
-
-void vdu_plot_circle(byte mode) {
-  	int a, b, r;
-  	switch(mode) {
-    	case 0x90 ... 0x93: // Circle
-      		r = 2 * (p1.X + p1.Y);
-      		Canvas->drawEllipse(p2.X, p2.Y, r, r);
-      		break;
-    	case 0x94 ... 0x97: // Circle
-      		a = p2.X - p1.X;
-      		b = p2.Y - p1.Y;
-      		r = 2 * sqrt(a * a + b * b);
-      		Canvas->drawEllipse(p2.X, p2.Y, r, r);
-      		break;
-  	}
 }
 
 // VDU 25 Handle PLOT
 //
 void vdu_plot() {
-  	int mode = readByte_t(); if(mode == -1) return;
+  	int mode = readByte_t(); if (mode == -1) return;
 
-	int x = readWord_t(); if(x == -1) return; else x = (short)x;
-	int y = readWord_t(); if(y == -1) return; else y = (short)y;
+	int x = readWord_t(); if (x == -1) return; else x = (short)x;
+	int y = readWord_t(); if (y == -1) return; else y = (short)y;
 
-  	p3 = p2;
-  	p2 = p1;
-	p1 = translateViewport(scale(x, y));
-	Canvas->setClippingRect(graphicsViewport);
-	Canvas->setPenColor(gfg);
-	Canvas->setPaintOptions(gpo);
+    pushPoint(x, y);
+    setGraphicsOptions();
+
 	debug_log("vdu_plot: mode %d, (%d,%d) -> (%d,%d)\n\r", mode, x, y, p1.X, p1.Y);
-  	switch(mode) {
-    	case 0x04: 			// Move 
-      		Canvas->moveTo(p1.X, p1.Y);
+  	switch (mode) {
+    	case 0x04: 			// Move
+            moveTo();
       		break;
     	case 0x05: 			// Line
-      		Canvas->lineTo(p1.X, p1.Y);
+            plotLine();
       		break;
 		case 0x40 ... 0x47:	// Point
-			Canvas->setPixel(p1.X, p1.Y);
+			plotPoint();
 			break;
     	case 0x50 ... 0x57: // Triangle
-      		vdu_plot_triangle(mode);
+      		plotTriangle(mode - 0x50);
       		break;
     	case 0x90 ... 0x97: // Circle
-      		vdu_plot_circle(mode);
+            plotCircle(mode - 0x90);
       		break;
   	}
-	doWaitCompletion = true;
+	waitPlotCompletion();
 }
 
 // VDU 26 Reset graphics and text viewports
@@ -235,9 +122,9 @@ void vdu_textViewport() {
 //
 void vdu_origin() {
 	int x = readWord_t();
-	if(x >= 0) {
+	if (x >= 0) {
 		int y = readWord_t();
-		if(y >= 0) {
+		if (y >= 0) {
 			setOrigin(x, y);
 			debug_log("vdu_origin: %d,%d\n\r", x, y);
 		}
@@ -261,19 +148,18 @@ void vdu_cursorTab() {
 void vdu(byte c) {
 	bool useTextCursor = (activeCursor == &textCursor);
 
-    doWaitCompletion = false;
     switch(c) {
         case 0x04:	
             // enable text cursor
-            Canvas->setGlyphOptions(GlyphOptions().FillBackground(true));
-            activeCursor = &textCursor;
-            activeViewport = &textViewport;
+            setCharacterOverwrite(true);
+            setActiveCursor(getTextCursor());
+            setActiveViewport(VIEWPORT_TEXT);
             break;
         case 0x05:
             // enable graphics cursor
-            Canvas->setGlyphOptions(GlyphOptions().FillBackground(false));
-            activeCursor = &p1;
-            activeViewport = &graphicsViewport;
+            setCharacterOverwrite(false);
+            setActiveCursor(getGraphicsCursor());
+            setActiveViewport(VIEWPORT_GRAPHICS);
             break;
         case 0x07:	// Bell
             play_note(0, 100, 750, 125);
@@ -342,27 +228,10 @@ void vdu(byte c) {
             break;
         case 0x20 ... 0x7E:
         case 0x80 ... 0xFF:
-            if (useTextCursor) {
-                Canvas->setClippingRect(defaultViewport);
-                Canvas->setPenColor(tfg);
-                Canvas->setBrushColor(tbg);
-                Canvas->setPaintOptions(tpo);
-            }
-            else {
-                Canvas->setClippingRect(graphicsViewport);
-                Canvas->setPenColor(gfg);
-                Canvas->setPaintOptions(gpo);
-            }
-            Canvas->drawChar(activeCursor->X, activeCursor->Y, c);
-            cursorRight();
+            plotCharacter(c);
             break;
         case 0x7F:  // Backspace
-            cursorLeft();
-            Canvas->setBrushColor(useTextCursor ? tbg : gbg);
-            Canvas->fillRectangle(activeCursor->X, activeCursor->Y, activeCursor->X + fontW - 1, activeCursor->Y + fontH - 1);
+            plotBackspace();
             break;
-    }
-    if (doWaitCompletion) {
-        Canvas->waitCompletion(false);
     }
 }

--- a/video/vdu_sprites.h
+++ b/video/vdu_sprites.h
@@ -1,0 +1,171 @@
+#ifndef _VDU_SPRITES_H_
+#define _VDU_SPRITES_H_
+
+#include <Arduino.h>
+#include <fabgl.h>
+
+#include "sprites.h"
+#include "vdp_protocol.h"
+
+void receiveBitmap(int cmd, uint16_t width, uint16_t height) {
+	//
+	// Allocate new heap data
+	//
+	void * dataptr = (void *)heap_caps_malloc(sizeof(uint32_t)*width*height, MALLOC_CAP_SPIRAM);
+
+	if (dataptr != NULL) {                  
+		if (cmd == 1) {
+			//
+			// Read data to the new databuffer
+			//
+			for (int n = 0; n < width*height; n++) ((uint32_t *)dataptr)[n] = readLong_b();  
+			debug_log("vdu_sys_sprites: bitmap %d - data received - width %d, height %d\n\r", getCurrentBitmap(), width, height);
+		}
+		if (cmd == 2) {
+			uint32_t color = readLong_b();
+			//
+			// Define single color
+			//
+			for (int n = 0; n < width*height; n++) ((uint32_t *)dataptr)[n] = color;            
+			debug_log("vdu_sys_sprites: bitmap %d - set to solid color - width %d, height %d\n\r", getCurrentBitmap(), width, height);            
+		}
+		// Create bitmap structure
+		//
+		createBitmap(width,height,dataptr);
+	}
+	else { 
+		//
+		// Discard incoming serial data if failed to allocate memory
+		//
+		if (cmd == 1) {
+			discardBytes(4*width*height);
+		}
+		if (cmd == 2) {
+			discardBytes(4);
+		}
+		debug_log("vdu_sys_sprites: bitmap %d - data discarded, no memory available - width %d, height %d\n\r", getCurrentBitmap(), width, height);
+	}
+
+}
+
+// Sprite Engine
+//
+void vdu_sys_sprites(void) {
+	int cmd = readByte_t();
+
+	switch(cmd) {
+		case 0: {	// Select bitmap
+			int	rb = readByte_t();
+			if (rb >= 0) {
+				setCurrentBitmap(rb);
+				debug_log("vdu_sys_sprites: bitmap %d selected\n\r", getCurrentBitmap());
+			}
+		}	break;
+
+		case 1:		// Send bitmap data
+		case 2: {	// Define bitmap in single color
+			int rw = readWord_t(); if (rw == -1) return;
+			int rh = readWord_t(); if (rh == -1) return;
+
+			receiveBitmap(cmd, rw, rh);
+
+		}	break;
+
+		case 3: {	// Draw bitmap to screen (x,y)
+			int	rx = readWord_t(); if (rx == -1) return;
+			int ry = readWord_t(); if (ry == -1) return;
+
+			drawBitmap(rx,ry);
+			debug_log("vdu_sys_sprites: bitmap %d draw command\n\r", getCurrentBitmap());
+		}	break;
+
+	   /*
+		* Sprites
+		* 
+		* Sprite creation order:
+		* 1) Create bitmap(s) for sprite, or re-use bitmaps already created
+		* 2) Select the correct sprite ID (0-255). The GDU only accepts sequential sprite sets, starting from ID 0. All sprites must be adjacent to 0
+		* 3) Clear out any frames from previous program definitions
+		* 4) Add one or more frames to each sprite
+		* 5) Activate sprite to the GDU
+		* 6) Show sprites on screen / move them around as needed
+		* 7) Refresh
+		*/
+		case 4: {	// Select sprite
+			int b = readByte_t(); if (b == -1) return;
+			setCurrentSprite(b);
+			debug_log("vdu_sys_sprites: sprite %d selected\n\r", getCurrentSprite());
+		}	break;
+
+		case 5: {	// Clear frames
+			clearSpriteFrames();
+			debug_log("vdu_sys_sprites: sprite %d - all frames cleared\n\r", getCurrentSprite());
+		}	break;
+
+		case 6:	{	// Add frame to sprite
+			int b = readByte_t(); if (b == -1) return;
+			addSpriteFrame(b);
+			debug_log("vdu_sys_sprites: sprite %d - bitmap %d added as frame %d\n\r", getCurrentSprite(), b, getSprite()->framesCount-1);
+		}	break;
+
+		case 7:	{	// Active sprites to GDU
+			int b = readByte_t(); if (b == -1) return;
+			activateSprites(b);
+			debug_log("vdu_sys_sprites: %d sprites activated\n\r", numsprites);
+		}	break;
+
+		case 8: {	// Set next frame on sprite
+			nextSpriteFrame();
+			debug_log("vdu_sys_sprites: sprite %d next frame\n\r", getCurrentSprite());
+		}	break;
+
+		case 9:	{	// Set previous frame on sprite
+			previousSpriteFrame();
+			debug_log("vdu_sys_sprites: sprite %d previous frame\n\r", getCurrentSprite());
+		}	break;
+
+		case 10: {	// Set current frame id on sprite
+			int b = readByte_t(); if (b == -1) return;
+			setSpriteFrame(b);
+			debug_log("vdu_sys_sprites: sprite %d set to frame %d\n\r", getCurrentSprite(), b);
+		}	break;
+
+		case 11: {	// Show sprite
+			showSprite();
+			debug_log("vdu_sys_sprites: sprite %d show cmd\n\r", getCurrentSprite());
+		}	break;
+
+		case 12: {	// Hide sprite
+			hideSprite();
+			debug_log("vdu_sys_sprites: sprite %d hide cmd\n\r", getCurrentSprite());
+		}	break;
+
+		case 13: {	// Move sprite to coordinate on screen
+			int	rx = readWord_t(); if (rx == -1) return;
+			int ry = readWord_t(); if (ry == -1) return;
+			moveSprite(rx, ry);
+			debug_log("vdu_sys_sprites: sprite %d - move to (%d,%d)\n\r", getCurrentSprite(), rx, ry);
+		}	break;
+
+		case 14: {	// Move sprite by offset to current coordinate on screen
+			int	rx = readWord_t(); if (rx == -1) return;
+			int ry = readWord_t(); if (ry == -1) return;
+			moveSpriteBy(rx, ry);
+			debug_log("vdu_sys_sprites: sprite %d - move by offset (%d,%d)\n\r", getCurrentSprite(), rx, ry);
+		}	break;
+
+		case 15: {	// Refresh
+			refreshSprites();
+			debug_log("vdu_sys_sprites: perform sprite refresh\n\r");
+		}	break;
+
+		case 16: {	// Reset
+			cls(false);
+			resetSprites();
+			resetBitmaps();
+			debug_log("vdu_sys_sprites: reset\n\r");
+		}	break;
+	}
+}
+
+#endif // _VDU_SPRITES_H_

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -6,7 +6,6 @@
 #include <ESP32Time.h>
 
 #include "agon.h"
-#include "agon_fonts.h"
 #include "agon_keyboard.h"
 #include "cursor.h"
 #include "graphics.h"

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -11,9 +11,9 @@
 #include "cursor.h"
 #include "graphics.h"
 #include "vdp_protocol.h"
+#include "vdu_sprites.h"
 
 extern void switchTerminalMode();			// Switch to terminal mode
-extern void vdu_sys_sprites();				// Sprite handler
 extern void vdu_sys_audio();				// Audio handler
 extern word play_note(byte channel, byte volume, word frequency, word duration);
 
@@ -149,9 +149,9 @@ void vdu_sys_keystate() {
 // These can send responses back; the response contains a packet # that matches the VDU command mode byte
 //
 void vdu_sys_video() {
-  	int	mode = readByte_t();
+	int	mode = readByte_t();
 
-  	switch (mode) {
+	switch (mode) {
 		case VDP_GP: {					// VDU 23, 0, &80
 			sendGeneralPoll();			// Send a general poll packet
 		}	break;
@@ -170,7 +170,7 @@ void vdu_sys_video() {
 			int x = readWord_t();		// Get pixel value at screen position x, y
 			int y = readWord_t();
 			sendScreenPixel((short)x, (short)y);
-		} 	break;		
+		}	break;		
 		case VDP_AUDIO: {				// VDU 23, 0, &85, channel, command, <args>
 			vdu_sys_audio();
 		}	break;
@@ -207,7 +207,7 @@ void vdu_sys_video() {
 // VDU 23,7: Scroll rectangle on screen
 //
 void vdu_sys_scroll() {
-	int extent = readByte_t(); 		if (extent == -1) return;	// Extent (0 = text viewport, 1 = entire screen, 2 = graphics viewport)
+	int extent = readByte_t();		if (extent == -1) return;	// Extent (0 = text viewport, 1 = entire screen, 2 = graphics viewport)
 	int direction = readByte_t();	if (direction == -1) return;	// Direction
 	int movement = readByte_t();	if (movement == -1) return;	// Number of pixels to scroll
 
@@ -251,7 +251,7 @@ void vdu_sys_udg(byte c) {
 // VDU 23,mode
 //
 void vdu_sys() {
-  	int mode = readByte_t();
+	int mode = readByte_t();
 
 	//
 	// If mode is -1, then there's been a timeout
@@ -263,7 +263,7 @@ void vdu_sys() {
 	// If mode < 32, then it's a system command
 	//
 	else if (mode < 32) {
-  		switch (mode) {
+		switch (mode) {
 			case 0x00: {					// VDU 23, 0
 	  			vdu_sys_video();			// Video system control
 			}	break;
@@ -282,7 +282,7 @@ void vdu_sys() {
 			case 0x1B: {					// VDU 23, 27
 				vdu_sys_sprites();			// Sprite system control
 			}	break;
-  		}
+		}
 	}
 	//
 	// Otherwise, do

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -7,10 +7,10 @@
 
 #include "agon.h"
 #include "agon_fonts.h"
+#include "agon_keyboard.h"
 #include "cursor.h"
 #include "vdp_protocol.h"
 
-extern fabgl::PS2Controller PS2Controller;
 extern int VGAColourDepth;					// Number of colours per pixel (2, 4,8, 16 or 64)
 extern Point p1, p2, p3;						// Coordinate store for plot
 extern RGB888 gfg, gbg;						// Graphics foreground and background colour
@@ -18,8 +18,6 @@ extern RGB888 tfg, tbg;						// Text foreground and background colour
 extern uint8_t palette[64];					// Storage for the palette
 extern const RGB888 colourLookup[64];		// Lookup table for VGA colours
 extern int videoMode;						// Current video mode
-extern int kbRepeatDelay;					// Keyboard repeat delay ms (250, 500, 750 or 1000)		
-extern int kbRepeatRate;					// Keyboard repeat rate ms (between 33 and 500)
 extern bool legacyModes;					// Default legacy modes being false
 extern bool doubleBuffered;					// Disable double buffering by default
 extern void switchTerminalMode();			// Switch to terminal mode
@@ -98,20 +96,7 @@ void sendGeneralPoll() {
 //
 void vdu_sys_video_kblayout() {
 	int	region = readByte_t();			// Fetch the region
-	// TODO refactor out setting layout to keyboard handling file
-	switch(region) {
-		case 1:	PS2Controller.keyboard()->setLayout(&fabgl::USLayout); break;
-		case 2:	PS2Controller.keyboard()->setLayout(&fabgl::GermanLayout); break;
-		case 3:	PS2Controller.keyboard()->setLayout(&fabgl::ItalianLayout); break;
-		case 4:	PS2Controller.keyboard()->setLayout(&fabgl::SpanishLayout); break;
-		case 5: PS2Controller.keyboard()->setLayout(&fabgl::FrenchLayout); break;
-		case 6:	PS2Controller.keyboard()->setLayout(&fabgl::BelgianLayout); break;
-		case 7:	PS2Controller.keyboard()->setLayout(&fabgl::NorwegianLayout); break;
-		case 8:	PS2Controller.keyboard()->setLayout(&fabgl::JapaneseLayout);break;
-		default:
-			PS2Controller.keyboard()->setLayout(&fabgl::UKLayout);
-			break;
-	}
+	setKeyboardLayout(region);
 }
 
 // VDU 23, 0, &82: Send the cursor position back to MOS
@@ -224,16 +209,16 @@ void vdu_sys_video_time() {
 // Send the keyboard state
 //
 void sendKeyboardState() {
-	bool numLock;
-	bool capsLock;
-	bool scrollLock;
-	PS2Controller.keyboard()->getLEDs(&numLock, &capsLock, &scrollLock);
+	int delay;
+	int rate;
+	byte ledState;
+	getKeyboardState(&delay, &rate, &ledState);
 	byte packet[] = {
-		kbRepeatDelay & 0xFF,
-		(kbRepeatDelay >> 8) & 0xFF,
-		kbRepeatRate & 0xFF,
-		(kbRepeatRate >> 8) & 0xFF,
-		scrollLock | (capsLock << 1) | (numLock << 2)
+		delay & 0xFF,
+		(delay >> 8) & 0xFF,
+		rate & 0xFF,
+		(rate >> 8) & 0xFF,
+		ledState
 	};
 	send_packet(PACKET_KEYSTATE, sizeof packet, packet);
 }
@@ -242,19 +227,12 @@ void sendKeyboardState() {
 // Send 255 for LEDs to leave them unchanged
 //
 void vdu_sys_keystate() {
-	// TODO refactor keyboard handling things to keyboard.h
-	int d = readWord_t(); if (d == -1) return;
-	int r = readWord_t(); if (r == -1) return;
-	int b = readByte_t(); if (b == -1) return;
+	int delay = readWord_t(); if (delay == -1) return;
+	int rate = readWord_t(); if (rate == -1) return;
+	int ledState = readByte_t(); if (ledState == -1) return;
 
-	if (d >= 250 && d <= 1000) kbRepeatDelay = (d / 250) * 250;	// In steps of 250ms
-	if (r >=  33 && r <=  500) kbRepeatRate  = r;
-
-	if (b != 255) {
-		PS2Controller.keyboard()->setLEDs(b & 4, b & 2, b & 1);
-	}
-	PS2Controller.keyboard()->setTypematicRateAndDelay(kbRepeatRate, kbRepeatDelay);
-	debug_log("vdu_sys_video: keystate: d=%d, r=%d, led=%d\n\r", kbRepeatDelay, kbRepeatRate, b);
+	setKeyboardState(delay, rate, ledState);
+	debug_log("vdu_sys_video: keystate: delay=%d, rate=%d, led=%d\n\r", kbRepeatDelay, kbRepeatRate, ledState);
 	sendKeyboardState();
 }
 

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -1,0 +1,457 @@
+#ifndef VDU_SYS_H
+#define VDU_SYS_H
+
+#include <Arduino.h>
+#include <fabgl.h>
+#include <ESP32Time.h>
+
+#include "agon.h"
+#include "agon_fonts.h"
+#include "cursor.h"
+#include "vdp_protocol.h"
+
+extern fabgl::PS2Controller PS2Controller;
+extern int VGAColourDepth;					// Number of colours per pixel (2, 4,8, 16 or 64)
+extern Point p1, p2, p3;						// Coordinate store for plot
+extern RGB888 gfg, gbg;						// Graphics foreground and background colour
+extern RGB888 tfg, tbg;						// Text foreground and background colour
+extern uint8_t palette[64];					// Storage for the palette
+extern const RGB888 colourLookup[64];		// Lookup table for VGA colours
+extern int videoMode;						// Current video mode
+extern int kbRepeatDelay;					// Keyboard repeat delay ms (250, 500, 750 or 1000)		
+extern int kbRepeatRate;					// Keyboard repeat rate ms (between 33 and 500)
+extern bool legacyModes;					// Default legacy modes being false
+extern bool doubleBuffered;					// Disable double buffering by default
+extern void switchTerminalMode();			// Switch to terminal mode
+extern void vdu_sys_sprites();				// Sprite handler
+extern void vdu_sys_audio();				// Audio handler
+extern word play_note(byte channel, byte volume, word frequency, word duration);
+
+bool 			initialised = false;			// Is the system initialised yet?
+ESP32Time		rtc(0);							// The RTC
+
+
+//// TODO: move to text.h file
+
+bool cmp_char(uint8_t * c1, uint8_t *c2, int len) {
+	for (int i = 0; i < len; i++) {
+		if (*c1++ != *c2++) {
+			return false;
+		}
+	}
+	return true;
+}
+
+// Try and match a character
+//
+char get_screen_char(int px, int py) {
+	RGB888	pixel;
+	uint8_t	charRow;
+	uint8_t	charData[8];
+	uint8_t R = tbg.R;
+	uint8_t G = tbg.G;
+	uint8_t B = tbg.B;
+
+	// Do some bounds checking first
+	//
+	if (px < 0 || py < 0 || px >= canvasW - 8 || py >= canvasH - 8) {
+		return 0;
+	}
+
+	// Now scan the screen and get the 8 byte pixel representation in charData
+	//
+	for (int y = 0; y < 8; y++) {
+		charRow = 0;
+		for (int x = 0; x < 8; x++) {
+			pixel = Canvas->getPixel(px + x, py + y);
+			if (!(pixel.R == R && pixel.G == G && pixel.B == B)) {
+				charRow |= (0x80 >> x);
+			}
+		}
+		charData[y] = charRow;
+	}
+	//
+	// Finally try and match with the character set array
+	//
+	for (int i = 32; i <= 255; i++) {
+		if (cmp_char(charData, &fabgl::FONT_AGON_DATA[i * 8], 8)) {	
+			return i;		
+		}
+	}
+	return 0;
+}
+
+
+
+// VDU 23, 0, &80, <echo>: Send a general poll/echo byte back to MOS
+//
+void sendGeneralPoll() {
+	byte b = readByte_b();
+	byte packet[] = {
+		b,
+	};
+	send_packet(PACKET_GP, sizeof packet, packet);
+	initialised = true;	
+}
+
+// VDU 23, 0, &81, <region>: Set the keyboard layout
+//
+void vdu_sys_video_kblayout() {
+	int	region = readByte_t();			// Fetch the region
+	// TODO refactor out setting layout to keyboard handling file
+	switch(region) {
+		case 1:	PS2Controller.keyboard()->setLayout(&fabgl::USLayout); break;
+		case 2:	PS2Controller.keyboard()->setLayout(&fabgl::GermanLayout); break;
+		case 3:	PS2Controller.keyboard()->setLayout(&fabgl::ItalianLayout); break;
+		case 4:	PS2Controller.keyboard()->setLayout(&fabgl::SpanishLayout); break;
+		case 5: PS2Controller.keyboard()->setLayout(&fabgl::FrenchLayout); break;
+		case 6:	PS2Controller.keyboard()->setLayout(&fabgl::BelgianLayout); break;
+		case 7:	PS2Controller.keyboard()->setLayout(&fabgl::NorwegianLayout); break;
+		case 8:	PS2Controller.keyboard()->setLayout(&fabgl::JapaneseLayout);break;
+		default:
+			PS2Controller.keyboard()->setLayout(&fabgl::UKLayout);
+			break;
+	}
+}
+
+// VDU 23, 0, &82: Send the cursor position back to MOS
+//
+void sendCursorPosition() {
+	byte packet[] = {
+		textCursor.X / fontW,
+		textCursor.Y / fontH,
+	};
+	send_packet(PACKET_CURSOR, sizeof packet, packet);	
+}
+	
+// VDU 23, 0, &83 Send a character back to MOS
+//
+void sendScreenChar(int x, int y) {
+	int	px = x * fontW;
+	int py = y * fontH;
+	char c = get_screen_char(px, py);
+	byte packet[] = {
+		c,
+	};
+	send_packet(PACKET_SCRCHAR, sizeof packet, packet);
+}
+
+// VDU 23, 0, &84: Send a pixel value back to MOS
+//
+void sendScreenPixel(int x, int y) {
+	// TODO refactor VGA and colour things
+	RGB888	pixel;
+	byte 	pixelIndex = 0;
+	Point	p = translateViewport(scale(x, y));
+	//
+	// Do some bounds checking first
+	//
+	if (p.X >= 0 && p.Y >= 0 && p.X < canvasW && p.Y < canvasH) {
+		pixel = Canvas->getPixel(p.X, p.Y);
+		for (byte i = 0; i < VGAColourDepth; i++) {
+			if (colourLookup[palette[i]] == pixel) {
+				pixelIndex = i;
+				break;
+			}
+		}
+	}	
+	byte packet[] = {
+		pixel.R,	// Send the colour components
+		pixel.G,
+		pixel.B,
+		pixelIndex,	// And the pixel index in the palette
+	};
+	send_packet(PACKET_SCRPIXEL, sizeof packet, packet);	
+}
+
+// VDU 23, 0, &86: Send MODE information (screen details)
+//
+void sendModeInformation() {
+	// TODO refactor VGA and mode things
+	byte packet[] = {
+		canvasW & 0xFF,	 					// Width in pixels (L)
+		(canvasW >> 8) & 0xFF,				// Width in pixels (H)
+		canvasH & 0xFF,						// Height in pixels (L)
+		(canvasH >> 8) & 0xFF,				// Height in pixels (H)
+		canvasW / fontW,					// Width in characters (byte)
+		canvasH / fontH,					// Height in characters (byte)
+		VGAColourDepth,						// Colour depth
+		videoMode,							// The video mode number
+	};
+	send_packet(PACKET_MODE, sizeof packet, packet);
+}
+
+// Send TIME information (from ESP32 RTC)
+//
+void sendTime() {
+	byte packet[] = {
+		rtc.getYear() - EPOCH_YEAR,			// 0 - 255
+		rtc.getMonth(),						// 0 - 11
+		rtc.getDay(),						// 1 - 31
+		rtc.getDayofYear(),					// 0 - 365
+		rtc.getDayofWeek(),					// 0 - 6
+		rtc.getHour(true),					// 0 - 23
+		rtc.getMinute(),					// 0 - 59
+		rtc.getSecond(),					// 0 - 59
+	};
+	send_packet(PACKET_RTC, sizeof packet, packet);
+}
+
+// VDU 23, 0, &87, <mode>, [args]: Handle time requests
+//
+void vdu_sys_video_time() {
+	int mode = readByte_t();
+
+	if (mode == 0) {
+		sendTime();
+	}
+	else if (mode == 1) {
+		int yr = readByte_t(); if (yr == -1) return;
+		int mo = readByte_t(); if (mo == -1) return;
+		int da = readByte_t(); if (da == -1) return;
+		int ho = readByte_t(); if (ho == -1) return;	
+		int mi = readByte_t(); if (mi == -1) return;
+		int se = readByte_t(); if (se == -1) return;
+
+		yr = EPOCH_YEAR + (int8_t)yr;
+
+		if (yr >= 1970) {
+			rtc.setTime(se, mi, ho, da, mo, yr);
+		}
+	}
+}
+
+// Send the keyboard state
+//
+void sendKeyboardState() {
+	bool numLock;
+	bool capsLock;
+	bool scrollLock;
+	PS2Controller.keyboard()->getLEDs(&numLock, &capsLock, &scrollLock);
+	byte packet[] = {
+		kbRepeatDelay & 0xFF,
+		(kbRepeatDelay >> 8) & 0xFF,
+		kbRepeatRate & 0xFF,
+		(kbRepeatRate >> 8) & 0xFF,
+		scrollLock | (capsLock << 1) | (numLock << 2)
+	};
+	send_packet(PACKET_KEYSTATE, sizeof packet, packet);
+}
+
+// VDU 23, 0, &88, delay; repeatRate; LEDs: Handle the keystate
+// Send 255 for LEDs to leave them unchanged
+//
+void vdu_sys_keystate() {
+	// TODO refactor keyboard handling things to keyboard.h
+	int d = readWord_t(); if (d == -1) return;
+	int r = readWord_t(); if (r == -1) return;
+	int b = readByte_t(); if (b == -1) return;
+
+	if (d >= 250 && d <= 1000) kbRepeatDelay = (d / 250) * 250;	// In steps of 250ms
+	if (r >=  33 && r <=  500) kbRepeatRate  = r;
+
+	if (b != 255) {
+		PS2Controller.keyboard()->setLEDs(b & 4, b & 2, b & 1);
+	}
+	PS2Controller.keyboard()->setTypematicRateAndDelay(kbRepeatRate, kbRepeatDelay);
+	debug_log("vdu_sys_video: keystate: d=%d, r=%d, led=%d\n\r", kbRepeatDelay, kbRepeatRate, b);
+	sendKeyboardState();
+}
+
+// VDU 23,0: VDP control
+// These can send responses back; the response contains a packet # that matches the VDU command mode byte
+//
+void vdu_sys_video() {
+  	int	mode = readByte_t();
+
+  	switch (mode) {
+		case VDP_GP: {					// VDU 23, 0, &80
+			sendGeneralPoll();			// Send a general poll packet
+		}	break;
+		case VDP_KEYCODE: {				// VDU 23, 0, &81, layout
+			vdu_sys_video_kblayout();
+		}	break;
+		case VDP_CURSOR: {				// VDU 23, 0, &82
+			sendCursorPosition();		// Send cursor position
+		}	break;
+		case VDP_SCRCHAR: {				// VDU 23, 0, &83, x; y;
+			int x = readWord_t();		// Get character at screen position x, y
+			int y = readWord_t();
+			sendScreenChar(x, y);
+		}	break;
+		case VDP_SCRPIXEL: {			// VDU 23, 0, &84, x; y;
+			int x = readWord_t();		// Get pixel value at screen position x, y
+			int y = readWord_t();
+			sendScreenPixel((short)x, (short)y);
+		} 	break;		
+		case VDP_AUDIO: {				// VDU 23, 0, &85, channel, command, <args>
+			vdu_sys_audio();
+		}	break;
+		case VDP_MODE: {				// VDU 23, 0, &86
+			sendModeInformation();		// Send mode information (screen dimensions, etc)
+		}	break;
+		case VDP_RTC: {					// VDU 23, 0, &87, mode
+			vdu_sys_video_time();		// Send time information
+		}	break;
+		case VDP_KEYSTATE: {			// VDU 23, 0, &88, repeatRate; repeatDelay; status
+			vdu_sys_keystate();
+		}	break;
+		case VDP_LOGICALCOORDS: {		// VDU 23, 0, &C0, n
+			int b = readByte_t();		// Set logical coord mode
+			if (b >= 0) {
+				logicalCoords = b;	
+			}
+		}	break;
+		case VDP_LEGACYMODES: {			// VDU 23, 0, &C1, n
+			int b = readByte_t();		// Switch legacy modes on or off
+			if (b == 0) {
+				legacyModes = false;
+			} else {
+				legacyModes = true;
+			}
+		}	break;
+		case VDP_SWITCHBUFFER: {		// VDU 23, 0, &C3
+			if (doubleBuffered == true) {
+				Canvas->swapBuffers();
+			}
+		}	break;
+		case VDP_TERMINALMODE: {		// VDU 23, 0, &FF
+			switchTerminalMode(); 		// Switch to terminal mode
+		}	break;
+  	}
+}
+
+// VDU 23,7: Scroll rectangle on screen
+//
+void vdu_sys_scroll() {
+	// TODO refactor to use scrolling handling inside viewport.h
+	int extent = readByte_t(); 		if(extent == -1) return;	// Extent (0 = text viewport, 1 = entire screen, 2 = graphics viewport)
+	int direction = readByte_t();	if(direction == -1) return;	// Direction
+	int movement = readByte_t();	if(movement == -1) return;	// Number of pixels to scroll
+
+	Rect * region;
+
+	switch(extent) {
+		case 0:		// Text viewport
+			region = &textViewport;
+			break;
+		case 2: 	// Graphics viewport
+			region = &graphicsViewport;
+			break;
+		default:	// Entire screen
+			region = &defaultViewport;
+			break;
+	}
+	Canvas->setScrollingRegion(region->X1, region->Y1, region->X2, region->Y2);
+
+	switch(direction) {
+		case 0:	// Right
+			Canvas->scroll(movement, 0);
+			break;
+		case 1: // Left
+			Canvas->scroll(-movement, 0);
+			break;
+		case 2: // Down
+			Canvas->scroll(0, movement);
+			break;
+		case 3: // Up
+			Canvas->scroll(0, -movement);
+			break;
+	}
+	Canvas->waitCompletion(false);
+}
+
+
+// VDU 23,16: Set cursor behaviour
+// 
+void vdu_sys_cursorBehaviour() {
+	int setting = readByte_t();	if (setting == -1) return;
+	int mask = readByte_t();	if (mask == -1) return;
+
+	setCursorBehaviour((byte) setting, (byte) mask);
+}
+
+// VDU 23, char, n1, n2, n3, n4, n5, n6, n7, n8: Redefine a display character
+// Parameters:
+// - c: The character to redefine
+//
+void vdu_sys_udg(byte c) {
+	uint8_t		buffer[8];
+	int			b;
+
+	for(int i = 0; i < 8; i++) {
+		b = readByte_t();
+		if(b == -1) {
+			return;
+		}
+		buffer[i] = b;
+	}	
+	// TODO refactor character redefinition to font handling file
+	memcpy(&fabgl::FONT_AGON_DATA[c * 8], buffer, 8);
+}
+
+
+// Handle SYS
+// VDU 23,mode
+//
+void vdu_sys() {
+  	int mode = readByte_t();
+
+	//
+	// If mode is -1, then there's been a timeout
+	//
+	if (mode == -1) {
+		return;
+	}
+	//
+	// If mode < 32, then it's a system command
+	//
+	else if (mode < 32) {
+  		switch(mode) {
+			case 0x00: {					// VDU 23, 0
+	  			vdu_sys_video();			// Video system control
+			}	break;
+			case 0x01: {					// VDU 23, 1
+				int b = readByte_t();		// Cursor control
+				if (b >= 0) {
+					enableCursor((bool) b);
+				}
+			}	break;
+			case 0x07: {					// VDU 23, 7
+				vdu_sys_scroll();			// Scroll 
+			}	break;
+			case 0x10: {					// VDU 23, 16
+				vdu_sys_cursorBehaviour();	// Set cursor behaviour
+				break;
+			}
+			case 0x1B: {					// VDU 23, 27
+				vdu_sys_sprites();			// Sprite system control
+			}	break;
+  		}
+	}
+	//
+	// Otherwise, do
+	// VDU 23,mode,n1,n2,n3,n4,n5,n6,n7,n8
+	// Redefine character with ASCII code mode
+	//
+	else {
+		vdu_sys_udg(mode);
+	}
+}
+
+// Wait for eZ80 to initialise
+//
+void wait_eZ80() {
+	debug_log("wait_eZ80: Start\n\r");
+	while (!initialised) {
+		if (byteAvailable()) {
+			byte c = readByte();	// Only handle VDU 23 packets
+			if (c == 23) {
+				vdu_sys();
+			}
+		}
+	}
+	debug_log("wait_eZ80: End\n\r");
+}
+
+#endif // VDU_SYS_H

--- a/video/video.ino
+++ b/video/video.ino
@@ -60,10 +60,10 @@ fabgl::Terminal				Terminal;			// Used for CP/M mode
 #include "agon_keyboard.h"						// Keyboard support
 #include "agon_screen.h"						// Screen support
 #include "graphics.h"							// Graphics support
+#include "cursor.h"								// Cursor support
 #include "vdp_protocol.h"						// VDP Protocol
 #include "vdu.h"								// VDU functions
 
-int				count = 0;						// Generic counter, incremented every iteration of loop
 bool			terminalMode = false;			// Terminal mode
 
 #if DEBUG == 1 || SERIALKB == 1
@@ -81,13 +81,14 @@ void setup() {
 	setupKeyboard();
 	init_audio();
 	copy_font();
-  	set_mode(1);
+	set_mode(1);
 	boot_screen();
 }
 
 // The main loop
 //
 void loop() {
+	int count = 0;						// Generic counter, incremented every loop iteration
 	bool cursorVisible = false;
 	bool cursorState = false;
 

--- a/video/video.ino
+++ b/video/video.ino
@@ -188,7 +188,7 @@ void debug_log(const char *format, ...) {
 //
 void switchTerminalMode() {
 	cls(true);
-	delete Canvas;
+	delete canvas;
 	Terminal.begin(getVGAController());	
 	Terminal.connectSerialPort(VDPSerial);
 	Terminal.enableCursor(true);

--- a/video/video.ino
+++ b/video/video.ino
@@ -44,7 +44,6 @@
 // 05/09/2023:					+ New audio enhancements, improved mode change code
 
 #include <fabgl.h>
-#include <ESP32Time.h>
 
 #define VERSION			1
 #define REVISION		4
@@ -74,28 +73,15 @@ fabgl::PaintOptions			tpo;				// Text paint options
 #include "agon_palette.h"						// Colour lookup table
 #include "vdu_audio.h"							// Audio support
 #include "vdp_protocol.h"						// VDP Protocol
+#include "vdu.h"								// VDU functions
+#include "viewport.h"							// Viewport support
 
 int				VGAColourDepth;					// Number of colours per pixel (2, 4,8, 16 or 64)
-Point			textCursor;						// Text cursor
-Point *			activeCursor;					// Pointer to the active text cursor (textCursor or p1)
-Rect *			activeViewport;					// Pointer to the active text viewport (textViewport or graphicsViewport)
-Point			origin;							// Screen origin
 Point       	p1, p2, p3;						// Coordinate store for plot
 RGB888    		gfg, gbg;						// Graphics foreground and background colour
 RGB888      	tfg, tbg;						// Text foreground and background colour
-Rect 			defaultViewport;				// Default viewport
-Rect 			textViewport;					// Text viewport
-Rect 			graphicsViewport;				// Graphics viewport
 int				fontW;							// Font width
 int				fontH;							// Font height
-int				canvasW;						// Canvas width
-int				canvasH;						// Canvas height
-bool			cursorEnabled = true;			// Cursor visibility
-byte			cursorBehaviour = 0;			// Cursor behavior
-bool			useViewports = false;			// Viewports are enabled
-bool			logicalCoords = true;			// Use BBC BASIC logical coordinates
-double			logicalScaleX;					// Scaling factor for logical coordinates
-double			logicalScaleY;
 int         	count = 0;						// Generic counter, incremented every iteration of loop
 uint8_t			numsprites = 0;					// Number of sprites on stage
 uint8_t 		current_sprite = 0; 			// Current sprite number
@@ -106,17 +92,12 @@ byte 			keycode = 0;					// Last pressed key code
 byte 			modifiers = 0;					// Last pressed key modifiers
 bool			terminalMode = false;			// Terminal mode
 int				videoMode;						// Current video mode
-bool 			pagedMode = false;				// Is output paged or not? Set by VDU 14 and 15
-int				pagedModeCount = 0;				// Scroll counter for paged mode
 int				kbRepeatDelay = 500;			// Keyboard repeat delay ms (250, 500, 750 or 1000)		
 int				kbRepeatRate = 100;				// Keyboard repeat rate ms (between 33 and 500)
-bool 			initialised = false;			// Is the system initialised yet?
 bool			doWaitCompletion;				// For vdu function
 uint8_t			palette[64];					// Storage for the palette
 bool			legacyModes = false;			// Default legacy modes being false
 bool			doubleBuffered = false;			// Disable double buffering by default
-
-ESP32Time	rtc(0);								// The RTC
 
 #if DEBUG == 1 || SERIALKB == 1
 HardwareSerial DBGSerial(0);
@@ -203,173 +184,38 @@ void copy_font() {
 	memcpy(fabgl::FONT_AGON_DATA + 256, fabgl::FONT_AGON_BITMAP, sizeof(fabgl::FONT_AGON_BITMAP));
 }
 
-// Send MODE information (screen details)
-//
-void sendModeInformation() {
-	byte packet[] = {
-		canvasW & 0xFF,	 					// Width in pixels (L)
-		(canvasW >> 8) & 0xFF,				// Width in pixels (H)
-		canvasH & 0xFF,						// Height in pixels (L)
-		(canvasH >> 8) & 0xFF,				// Height in pixels (H)
-		canvasW / fontW,					// Width in characters (byte)
-		canvasH / fontH,					// Height in characters (byte)
-		VGAColourDepth,						// Colour depth
-		videoMode,							// The video mode number
-	};
-	send_packet(PACKET_MODE, sizeof packet, packet);
-}
-
-// Send TIME information (from ESP32 RTC)
-//
-void sendTime() {
-	byte packet[] = {
-		rtc.getYear() - EPOCH_YEAR,			// 0 - 255
-		rtc.getMonth(),						// 0 - 11
-		rtc.getDay(),						// 1 - 31
-		rtc.getDayofYear(),					// 0 - 365
-		rtc.getDayofWeek(),					// 0 - 6
-		rtc.getHour(true),					// 0 - 23
-		rtc.getMinute(),					// 0 - 59
-		rtc.getSecond(),					// 0 - 59
-	};
-	send_packet(PACKET_RTC, sizeof packet, packet);
-}
-
-// Send the keyboard state
-//
-void sendKeyboardState() {
-	bool numLock;
-	bool capsLock;
-	bool scrollLock;
-	PS2Controller.keyboard()->getLEDs(&numLock, &capsLock, &scrollLock);
-	byte packet[] = {
-		kbRepeatDelay & 0xFF,
-		(kbRepeatDelay >> 8) & 0xFF,
-		kbRepeatRate & 0xFF,
-		(kbRepeatRate >> 8) & 0xFF,
-		scrollLock | (capsLock << 1) | (numLock << 2)
-	};
-	send_packet(PACKET_KEYSTATE, sizeof packet, packet);
-}
-
-// Send a general poll
-//
-void sendGeneralPoll() {
-	byte b = readByte_b();
-	byte packet[] = {
-		b,
-	};
-	send_packet(PACKET_GP, sizeof packet, packet);
-	initialised = true;	
-}
-
 // Clear the screen
 // 
 void cls(bool resetViewports) {
-	int i;
-
-	if(resetViewports) {
-		vdu_resetViewports();
+	if (resetViewports) {
+		viewportReset();
 	}
-	if(Canvas) {
+	if (Canvas) {
 		Canvas->setPenColor(tfg);
  		Canvas->setBrushColor(tbg);	
 		Canvas->setPaintOptions(tpo);
 		clearViewport(&textViewport);
 	}
-	if(numsprites) {
+	if (numsprites) {
 		if(VGAController) {
 			VGAController->removeSprites();
 			clearViewport(&textViewport);
 		}
 		numsprites = 0;
 	}
-	textCursor = Point(activeViewport->X1, activeViewport->Y1);
-	pagedModeCount = 0;
+	homeCursor();
+	setPagedMode();
 }
 
 // Clear the graphics area
 //
 void clg() {
-	if(Canvas) {
+	if (Canvas) {
 		Canvas->setPenColor(gfg);
  		Canvas->setBrushColor(gbg);	
 		Canvas->setPaintOptions(gpo);
 		clearViewport(&graphicsViewport);
 	}
-}
-
-// Clear a viewport
-//
-void clearViewport(Rect * viewport) {
-	if(Canvas) {
-		if(useViewports) {
-			Canvas->fillRectangle(*viewport);
-		}
-		else {
-			Canvas->clear();
-		}
-	}
-}
-
-// Get the paint options for a given GCOL mode
-//
-fabgl::PaintOptions getPaintOptions(int mode, fabgl::PaintOptions priorPaintOptions) {
-	fabgl::PaintOptions p = priorPaintOptions;
-	
-	switch(mode) {
-		case 0: p.NOT = 0; p.swapFGBG = 0; break;
-		case 4: p.NOT = 1; p.swapFGBG = 0; break;
-	}
-	return p;
-}
-
-// Try and match a character
-//
-char get_screen_char(int px, int py) {
-	RGB888	pixel;
-	uint8_t	charRow;
-	uint8_t	charData[8];
-	uint8_t R = tbg.R;
-	uint8_t G = tbg.G;
-	uint8_t B = tbg.B;
-
-	// Do some bounds checking first
-	//
-	if(px < 0 || py < 0 || px >= canvasW - 8 || py >= canvasH - 8) {
-		return 0;
-	}
-
-	// Now scan the screen and get the 8 byte pixel representation in charData
-	//
-	for(int y = 0; y < 8; y++) {
-		charRow = 0;
-		for(int x = 0; x < 8; x++) {
-			pixel = Canvas->getPixel(px + x, py + y);
-			if(!(pixel.R == R && pixel.G == G && pixel.B == B)) {
-				charRow |= (0x80 >> x);
-			}
-		}
-		charData[y] = charRow;
-	}
-	//
-	// Finally try and match with the character set array
-	//
-	for(int i = 32; i <= 255; i++) {
-		if(cmp_char(charData, &fabgl::FONT_AGON_DATA[i * 8], 8)) {	
-			return i;		
-		}
-	}
-	return 0;
-}
-
-bool cmp_char(uint8_t * c1, uint8_t *c2, int len) {
-	for(int i = 0; i < len; i++) {
-		if(*c1++ != *c2++) {
-			return false;
-		}
-	}
-	return true;
 }
 
 // Switch to terminal mode
@@ -398,22 +244,6 @@ fabgl::VGABaseController * get_VGAController(int colours) {
 		case 64: return VGAController64.instance();
 	}
 	return nullptr;
-}
-
-// Set a palette item
-// Parameters:
-// - l: The logical colour to change
-// - c: The new colour
-// 
-void setPaletteItem(int l, RGB888 c) {
-	if(l < VGAColourDepth) {
-		switch(VGAColourDepth) {
-			case 2: VGAController2.setPaletteItem(l, c); break;
-			case 4: VGAController4.setPaletteItem(l, c); break;
-			case 8: VGAController8.setPaletteItem(l, c); break;
-			case 16: VGAController16.setPaletteItem(l, c); break;
-		}
-	}
 }
 
 // Update the internal FabGL LUT
@@ -648,7 +478,7 @@ int change_mode(int mode) {
   	Canvas->selectFont(&fabgl::FONT_AGON);
   	Canvas->setGlyphOptions(GlyphOptions().FillBackground(true));
   	Canvas->setPenWidth(1);
-	origin = Point(0,0);
+	setOrigin(0,0);
 	p1 = Point(0,0);
 	p2 = Point(0,0);
 	p3 = Point(0,0);
@@ -658,11 +488,8 @@ int change_mode(int mode) {
 	fontH = Canvas->getFontInfo()->height;
 	logicalScaleX = LOGICAL_SCRW / (double)canvasW;
 	logicalScaleY = LOGICAL_SCRH / (double)canvasH;
-	cursorEnabled = true;
-	cursorBehaviour = 0;
-	vdu_resetViewports();
-	activeCursor = &textCursor;
-	pagedMode = false;
+	resetCursor();
+	viewportReset();
 	sendModeInformation();
 	debug_log("do_modeChange: canvas(%d,%d), scale(%f,%f)\n\r", canvasW, canvasH, logicalScaleX, logicalScaleY);
 	return 0;
@@ -816,8 +643,8 @@ void do_keyboard() {
 		// Handle some control keys
 		//
 		switch(keycode) {
-			case 14: pagedMode = true; break;
-			case 15: pagedMode = false; break;
+			case 14: setPagedMode(true); break;
+			case 15: setPagedMode(false); break;
 		}
 		// Create and send the packet back to MOS
 		//
@@ -829,712 +656,6 @@ void do_keyboard() {
 		};
 		send_packet(PACKET_KEYCODE, sizeof packet, packet);
 	}
-}
-
-// Render a cursor at the current screen position
-//
-void do_cursor() {
-	if(cursorEnabled) {
-	  	Canvas->swapRectangle(textCursor.X, textCursor.Y, textCursor.X + fontW - 1, textCursor.Y + fontH - 1);
-	}
-}
-
-// Scale a point
-//
-Point scale(Point p) {
-	return scale(p.X, p.Y);
-}
-Point scale(int X, int Y) {
-	if(logicalCoords) {
-		return Point((double)X / logicalScaleX, (double)Y / logicalScaleY);
-	}
-	return Point(X, Y);
-}
-
-// Translate a point relative to the graphics viewport
-//
-Point translateViewport(Point p) {
-	return translateViewport(p.X, p.Y);
-}
-Point translateViewport(int X, int Y) {
-	if(logicalCoords) {
-		return Point(graphicsViewport.X1 + (origin.X + X), graphicsViewport.Y2 - (origin.Y + Y));
-	}
-	return Point(graphicsViewport.X1 + (origin.X + X), graphicsViewport.Y1 + (origin.Y + Y));
-}
-
-// Translate a point relative to the canvas
-//
-Point translateCanvas(Point p) {
-	return translateCanvas(p.X, p.Y);
-}
-Point translateCanvas(int X, int Y) {
-	if(logicalCoords) {
-		return Point(origin.X + X, (canvasH - 1) - (origin.Y + Y));
-	}
-	return Point(origin.X + X, origin.Y + Y);
-}
-
-void vdu(byte c) {
-	bool useTextCursor = (activeCursor == &textCursor);
-
-	if(c >= 0x20 && c != 0x7F) {
-		if(useTextCursor) {
-			Canvas->setClippingRect(defaultViewport);
-			Canvas->setPenColor(tfg);
-			Canvas->setBrushColor(tbg);
-			Canvas->setPaintOptions(tpo);
-		}
-		else {
-			Canvas->setClippingRect(graphicsViewport);
-			Canvas->setPenColor(gfg);
-			Canvas->setPaintOptions(gpo);
-		}
-		Canvas->drawChar(activeCursor->X, activeCursor->Y, c);
-		cursorRight();
-	}
-	else {
-		doWaitCompletion = false;
-		switch(c) {
-			case 0x04:	
-  				Canvas->setGlyphOptions(GlyphOptions().FillBackground(true));
-				activeCursor = &textCursor;
-				activeViewport = &textViewport;
-				break;
-			case 0x05:
-  				Canvas->setGlyphOptions(GlyphOptions().FillBackground(false));
-				activeCursor = &p1;
-				activeViewport = &graphicsViewport;
-				break;
-			case 0x07:	// Bell
-				play_note(0, 100, 750, 125);
-				break;
-			case 0x08:  // Cursor Left
-				cursorLeft();
-				break;
-			case 0x09:  // Cursor Right
-				cursorRight();
-				break;
-			case 0x0A:  // Cursor Down
-				cursorDown();
-				break;
-			case 0x0B:  // Cursor Up
-				cursorUp();
-				break;
-			case 0x0C:  // CLS
-				cls(false);
-				break;
-			case 0x0D:  // CR
-				cursorCR();
-				break;
-			case 0x0E:	// Paged mode ON
-				pagedMode = true;
-				break;
-			case 0x0F:	// Paged mode OFF
-				pagedMode = false;
-				break;
-			case 0x10:	// CLG
-				clg();
-				break;
-			case 0x11:	// COLOUR
-				vdu_colour();
-				break;
-			case 0x12:  // GCOL
-				vdu_gcol();
-				break;
-			case 0x13:	// Define Logical Colour
-				vdu_palette();
-				break;
-			case 0x16:  // Mode
-				vdu_mode();
-				break;
-			case 0x17:  // VDU 23
-				vdu_sys();
-				break;
-			case 0x18:	// Define a graphics viewport
-				vdu_graphicsViewport();
-				break;
-			case 0x19:  // PLOT
-				vdu_plot();
-				break;
-			case 0x1A:	// Reset text and graphics viewports
-				vdu_resetViewports();
-				break;
-			case 0x1C:	// Define a text viewport
-				vdu_textViewport();
-				break;
-			case 0x1D:	// VDU_29
-				vdu_origin();
-			case 0x1E:	// Move cursor to top left of the viewport
-				cursorHome();
-				break;
-			case 0x1F:	// TAB(X,Y)
-				cursorTab();
-				break;
-			case 0x7F:  // Backspace
-				cursorLeft();
-				Canvas->setBrushColor(useTextCursor ? tbg : gbg);
-				Canvas->fillRectangle(activeCursor->X, activeCursor->Y, activeCursor->X + fontW - 1, activeCursor->Y + fontH - 1);
-				break;
-		}
-		if(doWaitCompletion) {
-			Canvas->waitCompletion(false);
-		}
-	}
-}
-
-// Move the active cursor back one character
-//
-void cursorLeft() {
-	activeCursor->X -= fontW;											
-  	if(activeCursor->X < activeViewport->X1) {								// If moved past left edge of active viewport then
-    	activeCursor->X = activeViewport->X1;								// Lock it there
-  	}
-}
-
-// Advance the active cursor right one character
-//
-void cursorRight() {
-  	activeCursor->X += fontW;											
-  	if(activeCursor->X > activeViewport->X2) {								// If advanced past right edge of active viewport
-		if(activeCursor == &textCursor || (~cursorBehaviour & 0x40)) {		// If it is a text cursor or VDU 5 CR/LF is enabled then
-    		cursorCR();														// Do carriage return
-   			cursorDown();													// and line feed
-		}
-  	}
-}
-
-// Move the active cursor down a line
-//
-void cursorDown() {
-	activeCursor->Y += fontH;
-	//
-	// If in graphics mode, then don't scroll, wrap to top
-	// 
-	if(activeCursor != &textCursor) {
-		if(activeCursor->Y > activeViewport->Y2) {	
-			activeCursor->Y = activeViewport->Y2;
-		}
-		return;
-	}
-	//
-	// Using the text cursor, so handle paging and scrolling
-	//
-	if(pagedMode) {
-		pagedModeCount++;
-		if(pagedModeCount >= (activeViewport->Y2 - activeViewport->Y1 + 1) / fontH) {
-			pagedModeCount = 0;
-			wait_shiftkey();
-		}
-	}
-	//
-	// Check if scroll required
-	//
-	if(activeCursor->Y > activeViewport->Y2) {
-		activeCursor->Y -= fontH;
-		if(~cursorBehaviour & 0x01) {
-			Canvas->setScrollingRegion(activeViewport->X1, activeViewport->Y1, activeViewport->X2, activeViewport->Y2);
-			Canvas->scroll(0, -fontH);
-		}
-		else {
-			activeCursor->X = activeViewport->X2 + 1;
-		}
-	}
-}
-
-// Move the active cursor up a line
-//
-void cursorUp() {	
-  	activeCursor->Y -= fontH;
-  	if(activeCursor->Y < activeViewport->Y1) {
-		activeCursor->Y = activeViewport->Y1;
-  	}
-}
-
-// Move the active cursor to the leftmost position in the viewport
-//
-void cursorCR() {
-  	activeCursor->X = activeViewport->X1;
-}
-
-// Move the active cursor to the top-left position in the viewport
-//
-void cursorHome() {
-	activeCursor->X = activeViewport->X1;
-	activeCursor->Y = activeViewport->Y1;
-}
-
-// TAB(x,y)
-//
-void cursorTab() {
-	int x = readByte_t();
-	if(x >= 0) {
-		int y = readByte_t();
-		if(y >= 0) {
-			activeCursor->X = x * fontW;
-			activeCursor->Y = y * fontH;
-		}
-	}
-}
-
-// Handle MODE
-//
-void vdu_mode() {
-  	int mode = readByte_t();
-	debug_log("vdu_mode: %d\n\r", mode);
-	if(mode >= 0) {
-	  	set_mode(mode);
-	}
-}
-
-// Handle VDU 24
-// Example: VDU 24,640;256;1152;896;
-//
-void vdu_graphicsViewport() {
-	int x1 = readWord_t();			// Left
-	int y2 = readWord_t();			// Bottom
-	int x2 = readWord_t();			// Right
-	int y1 = readWord_t();			// Top
-
-	Point p1 = translateCanvas(scale((short)x1, (short)y1));
-	Point p2 = translateCanvas(scale((short)x2, (short)y2));
-
-	if(p1.X >= 0 && p2.X < canvasW && p1.Y >= 0 && p2.Y < canvasH && p2.X > p1.X && p2.Y > p1.Y) {
-		graphicsViewport = Rect(p1.X, p1.Y, p2.X, p2.Y);
-		useViewports = true;
-		debug_log("vdu_graphicsViewport: OK %d,%d,%d,%d\n\r", p1.X, p1.Y, p2.X, p2.Y);
-	}
-	else {
-		debug_log("vdu_graphicsViewport: Invalid Viewport %d,%d,%d,%d\n\r", p1.X, p1.Y, p2.X, p2.Y);
-	}
-	Canvas->setClippingRect(graphicsViewport);
-}
-
-// Handle VDU 26
-//
-void vdu_resetViewports() {
-	defaultViewport = Rect(0, 0, canvasW - 1, canvasH - 1);
-	textViewport =	Rect(0, 0, canvasW - 1, canvasH - 1);
-	graphicsViewport = Rect(0, 0, canvasW - 1, canvasH - 1);
-	activeViewport = &textViewport;
-	useViewports = false;
-	debug_log("vdu_resetViewport\n\r");
-}
-
-// Handle VDU 28
-// Example: VDU 28,20,23,34,4
-//
-void vdu_textViewport() {
-	int x1 = readByte_t() * fontW;				// Left
-	int y2 = (readByte_t() + 1) * fontH - 1;	// Bottom
-	int x2 = (readByte_t() + 1) * fontW - 1;	// Right
-	int y1 = readByte_t() * fontH;				// Top
-
-	if(x2 >= canvasW) x2 = canvasW - 1;
-	if(y2 >= canvasH) y2 = canvasH - 1;
-
-	if(x1 >= 0 && y1 >= 0 && x2 > x1 && y2 > y1) {
-		textViewport = Rect(x1, y1, x2, y2);
-		useViewports = true;
-		if(activeCursor->X < x1 || activeCursor->X > x2 || activeCursor->Y < y1 || activeCursor->Y > y2) {
-			activeCursor->X = x1;
-			activeCursor->Y = y1;
-		}
-		debug_log("vdu_textViewport: OK %d,%d,%d,%d\n\r", x1, y1, x2, y2);
-	}
-	else {
-		debug_log("vdu_textViewport: Invalid Viewport %d,%d,%d,%d\n\r", x1, y1, x2, y2);
-	}
-}
-
-// Handle VDU 29
-//
-void vdu_origin() {
-	int x = readWord_t();
-	if(x >= 0) {
-		int y = readWord_t();
-		if(y >= 0) {
-			origin = scale(x, y);
-			debug_log("vdu_origin: %d,%d\n\r", origin.X, origin.Y);
-		}
-	}
-}
-
-// Handle COLOUR
-// 
-void vdu_colour() {
-	int		colour = readByte_t();
-	byte	c = palette[colour%VGAColourDepth];
-
-	if(colour >= 0 && colour < 64) {
-		tfg = colourLookup[c];
-		debug_log("vdu_colour: tfg %d = %02X : %02X,%02X,%02X\n\r", colour, c, tfg.R, tfg.G, tfg.B);
-	}
-	else if(colour >= 128 && colour < 192) {
-		tbg = colourLookup[c];
-		debug_log("vdu_colour: tbg %d = %02X : %02X,%02X,%02X\n\r", colour, c, tbg.R, tbg.G, tbg.B);	
-	}
-	else {
-		debug_log("vdu_colour: invalid colour %d\n\r", colour);
-	}
-}
-
-// Handle GCOL
-// 
-void vdu_gcol() {
-	int		mode = readByte_t();
-	int		colour = readByte_t();
-	
-	byte	c = palette[colour%VGAColourDepth];
-
-	if(mode >= 0 && mode <= 6) {
-		if(colour >= 0 && colour < 64) {
-			gfg = colourLookup[c];
-			debug_log("vdu_gcol: mode %d, gfg %d = %02X : %02X,%02X,%02X\n\r", mode, colour, c, gfg.R, gfg.G, gfg.B);
-		}
-		else if(colour >= 128 && colour < 192) {
-			gbg = colourLookup[c];
-			debug_log("vdu_gcol: mode %d, gbg %d = %02X : %02X,%02X,%02X\n\r", mode, colour, c, gbg.R, gbg.G, gbg.B);
-		}
-		else {
-			debug_log("vdu_gcol: invalid colour %d\n\r", colour);
-		}
-		gpo = getPaintOptions(mode, gpo);
-	}
-	else {
-		debug_log("vdu_gcol: invalid mode %d\n\r", mode);
-	}
-}
-
-// Handle palette
-//
-void vdu_palette() {
-	int l = readByte_t(); if(l == -1) return; // Logical colour
-	int p = readByte_t(); if(p == -1) return; // Physical colour
-	int r = readByte_t(); if(r == -1) return; // The red component
-	int g = readByte_t(); if(g == -1) return; // The green component
-	int b = readByte_t(); if(b == -1) return; // The blue component
-
-	RGB888 col;				// The colour to set
-
-	if(VGAColourDepth < 64) {			// If it is a paletted video mode
-		if(p == 255) {					// If p = 255, then use the RGB values
-			col = RGB888(r, g, b);
-		}
-		else if(p < 64) {				// If p < 64, then look the value up in the colour lookup table
-			col = colourLookup[p];
-		}
-		else {				
-			debug_log("vdu_palette: p=%d not supported\n\r", p);
-			return;
-		}
-		setPaletteItem(l, col);
-		doWaitCompletion = true;
-		debug_log("vdu_palette: %d,%d,%d,%d,%d\n\r", l, p, r, g, b);
-	}
-	else {
-		debug_log("vdu_palette: not supported in this mode\n\r");
-	}
-}
-
-// Handle PLOT
-//
-void vdu_plot() {
-  	int mode = readByte_t(); if(mode == -1) return;
-
-	int x = readWord_t(); if(x == -1) return; else x = (short)x;
-	int y = readWord_t(); if(y == -1) return; else y = (short)y;
-
-  	p3 = p2;
-  	p2 = p1;
-	p1 = translateViewport(scale(x, y));
-	Canvas->setClippingRect(graphicsViewport);
-	Canvas->setPenColor(gfg);
-	Canvas->setPaintOptions(gpo);
-	debug_log("vdu_plot: mode %d, (%d,%d) -> (%d,%d)\n\r", mode, x, y, p1.X, p1.Y);
-  	switch(mode) {
-    	case 0x04: 			// Move 
-      		Canvas->moveTo(p1.X, p1.Y);
-      		break;
-    	case 0x05: 			// Line
-      		Canvas->lineTo(p1.X, p1.Y);
-      		break;
-		case 0x40 ... 0x47:	// Point
-			Canvas->setPixel(p1.X, p1.Y);
-			break;
-    	case 0x50 ... 0x57: // Triangle
-      		vdu_plot_triangle(mode);
-      		break;
-    	case 0x90 ... 0x97: // Circle
-      		vdu_plot_circle(mode);
-      		break;
-  	}
-	doWaitCompletion = true;
-}
-
-void vdu_plot_triangle(byte mode) {
-  	Point p[3] = {
-		p3,
-		p2,
-		p1, 
-	};
-  	Canvas->setBrushColor(gfg);
-  	Canvas->fillPath(p, 3);
-  	Canvas->setBrushColor(tbg);
-}
-
-void vdu_plot_circle(byte mode) {
-  	int a, b, r;
-  	switch(mode) {
-    	case 0x90 ... 0x93: // Circle
-      		r = 2 * (p1.X + p1.Y);
-      		Canvas->drawEllipse(p2.X, p2.Y, r, r);
-      		break;
-    	case 0x94 ... 0x97: // Circle
-      		a = p2.X - p1.X;
-      		b = p2.Y - p1.Y;
-      		r = 2 * sqrt(a * a + b * b);
-      		Canvas->drawEllipse(p2.X, p2.Y, r, r);
-      		break;
-  	}
-}
-
-// Handle SYS
-// VDU 23,mode
-//
-void vdu_sys() {
-  	int mode = readByte_t();
-
-	//
-	// If mode is -1, then there's been a timeout
-	//
-	if(mode == -1) {
-		return;
-	}
-	//
-	// If mode < 32, then it's a system command
-	//
-	else if(mode < 32) {
-  		switch(mode) {
-		    case 0x00: {					// VDU 23, 0
-      			vdu_sys_video();			// Video system control
-			}	break;
-			case 0x01: {					// VDU 23, 1
-				int b = readByte_t();		// Cursor control
-				if(b >= 0) {
-					cursorEnabled = b;	
-				}
-			}	break;
-			case 0x07: {					// VDU 23, 7
-				vdu_sys_scroll();			// Scroll 
-			}	break;
-			case 0x10: {					// VDU 23, 16
-				vdu_sys_cursorBehaviour();	// Set cursor behaviour
-				break;
-			}
-			case 0x1B: {					// VDU 23, 27
-				vdu_sys_sprites();			// Sprite system control
-			}	break;
-  		}
-	}
-	//
-	// Otherwise, do
-	// VDU 23,mode,n1,n2,n3,n4,n5,n6,n7,n8
-	// Redefine character with ASCII code mode
-	//
-	else {
-		vdu_sys_udg(mode);
-	}
-}
-
-// Define a UDG
-// Parameters:
-// - c: The character to redefine
-//
-void vdu_sys_udg(byte c) {
-	uint8_t		buffer[8];
-	int			b;
-
-	for(int i = 0; i < 8; i++) {
-		b = readByte_t();
-		if(b == -1) {
-			return;
-		}
-		buffer[i] = b;
-	}	
-	memcpy(&fabgl::FONT_AGON_DATA[c * 8], buffer, 8);
-}
-
-// VDU 23,0: VDP control
-// These can send responses back; the response contains a packet # that matches the VDU command mode byte
-//
-void vdu_sys_video() {
-  	int	mode = readByte_t();
-
-  	switch(mode) {
-		case VDP_GP: {					// VDU 23, 0, &80
-			sendGeneralPoll();			// Send a general poll packet
-		}	break;
-		case VDP_KEYCODE: {				// VDU 23, 0, &81, layout
-			vdu_sys_video_kblayout();
-		}	break;
-		case VDP_CURSOR: {				// VDU 23, 0, &82
-			sendCursorPosition();		// Send cursor position
-		}	break;
-		case VDP_SCRCHAR: {				// VDU 23, 0, &83, x; y;
-			int x = readWord_t();		// Get character at screen position x, y
-			int y = readWord_t();
-			sendScreenChar(x, y);
-		}	break;
-		case VDP_SCRPIXEL: {			// VDU 23, 0, &84, x; y;
-			int x = readWord_t();		// Get pixel value at screen position x, y
-			int y = readWord_t();
-			sendScreenPixel((short)x, (short)y);
-		} 	break;		
-		case VDP_AUDIO: {				// VDU 23, 0, &85, channel, command, <args>
-			vdu_sys_audio();
-		}	break;
-		case VDP_MODE: {				// VDU 23, 0, &86
-			sendModeInformation();		// Send mode information (screen dimensions, etc)
-		}	break;
-		case VDP_RTC: {					// VDU 23, 0, &87, mode
-			vdu_sys_video_time();		// Send time information
-		}	break;
-		case VDP_KEYSTATE: {			// VDU 23, 0, &88, repeatRate; repeatDelay; status
-			vdu_sys_keystate();
-		}	break;
-		case VDP_LOGICALCOORDS: {		// VDU 23, 0, &C0, n
-			int b = readByte_t();		// Set logical coord mode
-			if(b >= 0) {
-				logicalCoords = b;	
-			}
-		}	break;
-		case VDP_LEGACYMODES: {			// VDU 23, 0, &C1, n
-			int b = readByte_t();		// Switch legacy modes on or off
-			if(b == 0) {
-				legacyModes = false;
-			} else {
-				legacyModes = true;
-			}
-		}	break;
-		case VDP_SWITCHBUFFER: {		// VDU 23, 0, &C3
-			if (doubleBuffered == true) {
-				Canvas->swapBuffers();
-			}
-		}	break;
-		case VDP_TERMINALMODE: {		// VDU 23, 0, &FF
-			switchTerminalMode(); 		// Switch to terminal mode
-		}	break;
-  	}
-}
-
-// Handle the keystate
-//
-void vdu_sys_keystate() {
-	int d = readWord_t(); if(d == -1) return;
-	int r = readWord_t(); if(r == -1) return;
-	int b = readByte_t(); if(b == -1) return;
-
-	if(d >= 250 && d <= 1000) kbRepeatDelay = (d / 250) * 250;	// In steps of 250ms
-	if(r >=  33 && r <=  500) kbRepeatRate  = r;
-
-	if(b != 255) {
-		PS2Controller.keyboard()->setLEDs(b & 4, b & 2, b & 1);
-	}
-	PS2Controller.keyboard()->setTypematicRateAndDelay(kbRepeatRate, kbRepeatDelay);
-	debug_log("vdu_sys_video: keystate: d=%d, r=%d, led=%d\n\r", kbRepeatDelay, kbRepeatRate, b);
-	sendKeyboardState();
-}
-
-// Set the keyboard layout
-//
-void vdu_sys_video_kblayout() {
-	int	region = readByte_t();			// Fetch the region
-	switch(region) {
-		case 1:	PS2Controller.keyboard()->setLayout(&fabgl::USLayout); break;
-		case 2:	PS2Controller.keyboard()->setLayout(&fabgl::GermanLayout); break;
-		case 3:	PS2Controller.keyboard()->setLayout(&fabgl::ItalianLayout); break;
-		case 4:	PS2Controller.keyboard()->setLayout(&fabgl::SpanishLayout); break;
-		case 5: PS2Controller.keyboard()->setLayout(&fabgl::FrenchLayout); break;
-		case 6:	PS2Controller.keyboard()->setLayout(&fabgl::BelgianLayout); break;
-		case 7:	PS2Controller.keyboard()->setLayout(&fabgl::NorwegianLayout); break;
-		case 8:	PS2Controller.keyboard()->setLayout(&fabgl::JapaneseLayout);break;
-		default:
-			PS2Controller.keyboard()->setLayout(&fabgl::UKLayout);
-			break;
-	}
-}
-
-// Handle time requests
-//
-void vdu_sys_video_time() {
-	int mode = readByte_t();
-
-	if(mode == 0) {
-		sendTime();
-	}
-	else if(mode == 1) {
-		int yr = readByte_t(); if(yr == -1) return;
-		int mo = readByte_t(); if(mo == -1) return;
-		int da = readByte_t(); if(da == -1) return;
-		int ho = readByte_t(); if(ho == -1) return;	
-		int mi = readByte_t(); if(mi == -1) return;
-		int se = readByte_t(); if(se == -1) return;
-
-		yr = EPOCH_YEAR + (int8_t)yr;
-
-		if(yr >= 1970) {
-			rtc.setTime(se, mi, ho, da, mo, yr);
-		}
-	}
-}
-
-// VDU 23,7: Scroll rectangle on screen
-//
-void vdu_sys_scroll() {
-	int extent = readByte_t(); 		if(extent == -1) return;	// Extent (0 = text viewport, 1 = entire screen, 2 = graphics viewport)
-	int direction = readByte_t();	if(direction == -1) return;	// Direction
-	int movement = readByte_t();	if(movement == -1) return;	// Number of pixels to scroll
-
-	Rect * region;
-
-	switch(extent) {
-		case 0:		// Text viewport
-			region = &textViewport;
-			break;
-		case 2: 	// Graphics viewport
-			region = &graphicsViewport;
-			break;
-		default:	// Entire screen
-			region = &defaultViewport;
-			break;
-	}
-	Canvas->setScrollingRegion(region->X1, region->Y1, region->X2, region->Y2);
-
-	switch(direction) {
-		case 0:	// Right
-			Canvas->scroll(movement, 0);
-			break;
-		case 1: // Left
-			Canvas->scroll(-movement, 0);
-			break;
-		case 2: // Down
-			Canvas->scroll(0, movement);
-			break;
-		case 3: // Up
-			Canvas->scroll(0, -movement);
-			break;
-	}
-	doWaitCompletion = true;
-}
-
-// VDU 23,16: Set cursor behaviour
-// 
-void vdu_sys_cursorBehaviour() {
-	int setting = readByte_t();	if(setting == -1) return;
-	int mask = readByte_t();	if(mask == -1) return;
-
-	cursorBehaviour = (cursorBehaviour & mask) ^ setting;
 }
 
 // Sprite Engine
@@ -1600,10 +721,10 @@ void vdu_sys_sprites(void) {
 				// Discard incoming serial data if failed to allocate memory
 				//
 				if (cmd == 1) {
-					for(n = 0; n < width*height; n++) readLong_b();
+					discardBytes(4*width*height);
 				}
 				if (cmd == 2) {
-					readLong_b();	
+					discardBytes(4);
 				}
 				debug_log("vdu_sys_sprites: bitmap %d - data discarded, no memory available - width %d, height %d\n\r", current_bitmap, width, height);
 			}

--- a/video/viewport.h
+++ b/video/viewport.h
@@ -1,0 +1,113 @@
+#ifndef VIEWPORT_H
+#define VIEWPORT_H
+
+#include <fabgl.h>
+
+#include "agon.h"
+#include "cursor.h"
+
+extern fabgl::Canvas * Canvas;
+
+Point			origin;							// Screen origin
+int				canvasW;						// Canvas width
+int				canvasH;						// Canvas height
+bool			logicalCoords = true;			// Use BBC BASIC logical coordinates
+double			logicalScaleX;					// Scaling factor for logical coordinates
+double			logicalScaleY;
+Rect *			activeViewport;					// Pointer to the active text viewport (textViewport or graphicsViewport)
+Rect 			defaultViewport;				// Default viewport
+Rect 			textViewport;					// Text viewport
+Rect 			graphicsViewport;				// Graphics viewport
+bool			useViewports = false;			// Viewports are enabled
+
+// Reset viewports to default
+//
+void viewportReset() {
+	defaultViewport = Rect(0, 0, canvasW - 1, canvasH - 1);
+	textViewport =	Rect(0, 0, canvasW - 1, canvasH - 1);
+	graphicsViewport = Rect(0, 0, canvasW - 1, canvasH - 1);
+	activeViewport = &textViewport;
+	useViewports = false;
+}
+
+// Clear a viewport
+//
+void clearViewport(Rect * viewport) {
+	if (Canvas) {
+		if (useViewports) {
+			Canvas->fillRectangle(*viewport);
+		}
+		else {
+			Canvas->clear();
+		}
+	}
+}
+
+// Translate a point relative to the graphics viewport
+//
+Point translateViewport(int X, int Y) {
+	if (logicalCoords) {
+		return Point(graphicsViewport.X1 + (origin.X + X), graphicsViewport.Y2 - (origin.Y + Y));
+	}
+	return Point(graphicsViewport.X1 + (origin.X + X), graphicsViewport.Y1 + (origin.Y + Y));
+}
+Point translateViewport(Point p) {
+	return translateViewport(p.X, p.Y);
+}
+
+// Scale a point
+//
+Point scale(int X, int Y) {
+	if (logicalCoords) {
+		return Point((double)X / logicalScaleX, (double)Y / logicalScaleY);
+	}
+	return Point(X, Y);
+}
+Point scale(Point p) {
+	return scale(p.X, p.Y);
+}
+
+// Translate a point relative to the canvas
+//
+Point translateCanvas(int X, int Y) {
+	if (logicalCoords) {
+		return Point(origin.X + X, (canvasH - 1) - (origin.Y + Y));
+	}
+	return Point(origin.X + X, origin.Y + Y);
+}
+Point translateCanvas(Point p) {
+	return translateCanvas(p.X, p.Y);
+}
+
+// Set graphics viewport
+bool setGraphicsViewport(short x1, short y1, short x2, short y2) {
+	Point p1 = translateCanvas(scale((short)x1, (short)y1));
+	Point p2 = translateCanvas(scale((short)x2, (short)y2));
+
+	if (p1.X >= 0 && p2.X < canvasW && p1.Y >= 0 && p2.Y < canvasH && p2.X > p1.X && p2.Y > p1.Y) {
+		graphicsViewport = Rect(p1.X, p1.Y, p2.X, p2.Y);
+		useViewports = true;
+    	Canvas->setClippingRect(graphicsViewport);
+        return true;
+    }
+    return false;
+}
+
+// Set text viewport
+bool setTextViewport(short x1, short y1, short x2, short y2) {
+	if (x2 >= canvasW) x2 = canvasW - 1;
+	if (y2 >= canvasH) y2 = canvasH - 1;
+
+	if (x1 >= 0 && y1 >= 0 && x2 > x1 && y2 > y1) {
+		textViewport = Rect(x1, y1, x2, y2);
+		useViewports = true;
+		return true;
+	}
+    return false;
+}
+
+inline void setOrigin(int x, int y) {
+    origin = scale(x, y);
+}
+
+#endif // VIEWPORT_H

--- a/video/viewport.h
+++ b/video/viewport.h
@@ -4,7 +4,6 @@
 #include <fabgl.h>
 
 #include "agon.h"
-#include "cursor.h"
 #include "graphics.h"
 
 extern void setClippingRect(Rect r);

--- a/video/viewport.h
+++ b/video/viewport.h
@@ -5,8 +5,10 @@
 
 #include "agon.h"
 #include "cursor.h"
+#include "graphics.h"
 
 extern fabgl::Canvas * Canvas;
+extern void setClippingRect(Rect r);
 
 Point			origin;							// Screen origin
 int				canvasW;						// Canvas width
@@ -30,17 +32,18 @@ void viewportReset() {
 	useViewports = false;
 }
 
-// Clear a viewport
-//
-void clearViewport(Rect * viewport) {
-	if (Canvas) {
-		if (useViewports) {
-			Canvas->fillRectangle(*viewport);
-		}
-		else {
-			Canvas->clear();
-		}
-	}
+Rect * getViewport(byte type) {
+    switch (type) {
+        case VIEWPORT_TEXT: return &textViewport;
+        case VIEWPORT_DEFAULT: return &defaultViewport;
+        case VIEWPORT_GRAPHICS: return &graphicsViewport;
+        case VIEWPORT_ACTIVE: return activeViewport;
+        default: return &defaultViewport;
+    }
+}
+
+void setActiveViewport(byte type) {
+    activeViewport = getViewport(type);
 }
 
 // Translate a point relative to the graphics viewport
@@ -81,13 +84,13 @@ Point translateCanvas(Point p) {
 
 // Set graphics viewport
 bool setGraphicsViewport(short x1, short y1, short x2, short y2) {
-	Point p1 = translateCanvas(scale((short)x1, (short)y1));
-	Point p2 = translateCanvas(scale((short)x2, (short)y2));
+	Point p1 = translateCanvas(scale(x1, y1));
+	Point p2 = translateCanvas(scale(x2, y2));
 
 	if (p1.X >= 0 && p2.X < canvasW && p1.Y >= 0 && p2.Y < canvasH && p2.X > p1.X && p2.Y > p1.Y) {
 		graphicsViewport = Rect(p1.X, p1.Y, p2.X, p2.Y);
 		useViewports = true;
-    	Canvas->setClippingRect(graphicsViewport);
+        setClippingRect(graphicsViewport);
         return true;
     }
     return false;
@@ -108,6 +111,17 @@ bool setTextViewport(short x1, short y1, short x2, short y2) {
 
 inline void setOrigin(int x, int y) {
     origin = scale(x, y);
+}
+
+inline void setCanvasWH(int w, int h) {
+    canvasW = w;
+    canvasH = h;
+	logicalScaleX = LOGICAL_SCRW / (double)canvasW;
+	logicalScaleY = LOGICAL_SCRH / (double)canvasH;
+}
+
+inline void setLogicalCoords(bool b) {
+    logicalCoords = b;
 }
 
 #endif // VIEWPORT_H

--- a/video/viewport.h
+++ b/video/viewport.h
@@ -7,7 +7,6 @@
 #include "cursor.h"
 #include "graphics.h"
 
-extern fabgl::Canvas * Canvas;
 extern void setClippingRect(Rect r);
 
 Point			origin;							// Screen origin
@@ -17,9 +16,9 @@ bool			logicalCoords = true;			// Use BBC BASIC logical coordinates
 double			logicalScaleX;					// Scaling factor for logical coordinates
 double			logicalScaleY;
 Rect *			activeViewport;					// Pointer to the active text viewport (textViewport or graphicsViewport)
-Rect 			defaultViewport;				// Default viewport
-Rect 			textViewport;					// Text viewport
-Rect 			graphicsViewport;				// Graphics viewport
+Rect			defaultViewport;				// Default viewport
+Rect			textViewport;					// Text viewport
+Rect			graphicsViewport;				// Graphics viewport
 bool			useViewports = false;			// Viewports are enabled
 
 // Reset viewports to default
@@ -33,17 +32,17 @@ void viewportReset() {
 }
 
 Rect * getViewport(byte type) {
-    switch (type) {
-        case VIEWPORT_TEXT: return &textViewport;
-        case VIEWPORT_DEFAULT: return &defaultViewport;
-        case VIEWPORT_GRAPHICS: return &graphicsViewport;
-        case VIEWPORT_ACTIVE: return activeViewport;
-        default: return &defaultViewport;
-    }
+	switch (type) {
+		case VIEWPORT_TEXT: return &textViewport;
+		case VIEWPORT_DEFAULT: return &defaultViewport;
+		case VIEWPORT_GRAPHICS: return &graphicsViewport;
+		case VIEWPORT_ACTIVE: return activeViewport;
+		default: return &defaultViewport;
+	}
 }
 
 void setActiveViewport(byte type) {
-    activeViewport = getViewport(type);
+	activeViewport = getViewport(type);
 }
 
 // Translate a point relative to the graphics viewport
@@ -90,10 +89,10 @@ bool setGraphicsViewport(short x1, short y1, short x2, short y2) {
 	if (p1.X >= 0 && p2.X < canvasW && p1.Y >= 0 && p2.Y < canvasH && p2.X > p1.X && p2.Y > p1.Y) {
 		graphicsViewport = Rect(p1.X, p1.Y, p2.X, p2.Y);
 		useViewports = true;
-        setClippingRect(graphicsViewport);
-        return true;
-    }
-    return false;
+		setClippingRect(graphicsViewport);
+		return true;
+	}
+	return false;
 }
 
 // Set text viewport
@@ -106,22 +105,22 @@ bool setTextViewport(short x1, short y1, short x2, short y2) {
 		useViewports = true;
 		return true;
 	}
-    return false;
+	return false;
 }
 
 inline void setOrigin(int x, int y) {
-    origin = scale(x, y);
+	origin = scale(x, y);
 }
 
 inline void setCanvasWH(int w, int h) {
-    canvasW = w;
-    canvasH = h;
+	canvasW = w;
+	canvasH = h;
 	logicalScaleX = LOGICAL_SCRW / (double)canvasW;
 	logicalScaleY = LOGICAL_SCRH / (double)canvasH;
 }
 
 inline void setLogicalCoords(bool b) {
-    logicalCoords = b;
+	logicalCoords = b;
 }
 
 #endif // VIEWPORT_H


### PR DESCRIPTION
Refactor of codebase to aid with readability and maintainability.

The code is _mostly_ identical to the existing code but functions and data declarations have been moved into separate files.  Some refactoring has been done to split functionality into separate functions to provide a cleaner separation.

In general, files named with a prefix of `agon` are responsible for hardware features, and those starting with `vdu` are handlers of the VDU byte stream.  Other files provide higher level capabilities and abstractions and are named according to their function.

Incorporates the screen mode change fix from #80 

This refactor mostly represents/mirrors the codebase that will form the basis of the VDP code for the Agon Console8.  The only differences at present is the Console8 version of the VDP code already includes the audio enhancements from #76, and further audio enhancements to add frequency envelope support.

The refactoring in this PR will allow for easier further refactoring to help make better use of PSRAM, thus reducing the use of internal RAM on the VDP.  This will enable work to be done on adding in various new features.
