### PR TITLE
Frequency envelopes

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -100,6 +100,8 @@
 #define AUDIO_ENVELOPE_NONE		0		// No envelope
 #define AUDIO_ENVELOPE_ADSR		1		// Simple ADSR volume envelope
 
+#define AUDIO_FREQUENCY_ENVELOPE_STEPPED	1		// Stepped frequency envelope
+
 #define AUDIO_STATUS_ACTIVE		0x01	// Has an active waveform
 #define AUDIO_STATUS_PLAYING	0x02	// Playing a note (not in release phase)
 #define AUDIO_STATUS_INDEFINITE	0x04	// Indefinite duration sound playing

--- a/video/agon.h
+++ b/video/agon.h
@@ -102,6 +102,10 @@
 
 #define AUDIO_FREQUENCY_ENVELOPE_STEPPED	1		// Stepped frequency envelope
 
+#define AUDIO_FREQUENCY_REPEATS 0x01	// Repeat/loop the frequency envelope
+#define AUDIO_FREQUENCY_CUMULATIVE	0x02	// Reset frequency envelope when looping
+#define AUDIO_FREQUENCY_RESTRICT	0x04	// Restrict frequency envelope to the range 0-65535
+
 #define AUDIO_STATUS_ACTIVE		0x01	// Has an active waveform
 #define AUDIO_STATUS_PLAYING	0x02	// Playing a note (not in release phase)
 #define AUDIO_STATUS_INDEFINITE	0x04	// Indefinite duration sound playing

--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -272,12 +272,15 @@ void audio_channel::setVolume(byte volume) {
 				break;
 			case AUDIO_STATE_PLAY_LOOP:
 				// we are looping, so an envelope may be active
-				if (volume == 0 && this->_duration == -1) {
-					// abort loop by setting a duration to now
+				if (volume == 0) {
+					// silence whilst looping always stops playback - curtail duration
 					this->_duration = millis() - this->_startTime;
-				}
-				if (!(this->_volumeEnvelope || this->_frequencyEnvelope)) {
-					// no envelope, so set volume to new value
+					// if there's a volume envelope, just allow release to happen, otherwise...
+					if (!this->_volumeEnvelope) {
+						this->_volume = 0;
+					}
+				} else {
+					// Change base volume level, so next loop iteration will use it
 					this->_volume = volume;
 				}
 				break;

--- a/video/envelopes/frequency.h
+++ b/video/envelopes/frequency.h
@@ -13,39 +13,70 @@ class FrequencyEnvelope {
 		virtual bool isFinished(uint16_t elapsed, long duration);
 };
 
-struct FrequencyStep {
-	int16_t increment;		// change of frequency per step
+struct FrequencyStepPhase {
+	int16_t adjustment;		// change of frequency per step
 	uint16_t number;		// number of steps
 };
 
 class SteppedFrequencyEnvelope : public FrequencyEnvelope {
 	public:
-		SteppedFrequencyEnvelope(std::shared_ptr<std::vector<FrequencyStep>> steps, uint16_t stepLength, bool repeats);
+		SteppedFrequencyEnvelope(std::shared_ptr<std::vector<FrequencyStepPhase>> phases, uint16_t stepLength, bool repeats);
 		uint16_t getFrequency(uint16_t baseFrequency, uint16_t elapsed, long duration);
 		bool isFinished(uint16_t elapsed, long duration);
 	private:
-		std::shared_ptr<std::vector<FrequencyStep>> _steps;
+		std::shared_ptr<std::vector<FrequencyStepPhase>> _phases;
 		long _stepLength;
-		long _totalLength;
+		int _totalSteps;
+		int _totalAdjustment;
+		int _totalLength;
 		bool _repeats;
 };
 
-SteppedFrequencyEnvelope::SteppedFrequencyEnvelope(std::shared_ptr<std::vector<FrequencyStep>> steps, uint16_t stepLength, bool repeats)
-	: _steps(steps), _stepLength(stepLength), _repeats(repeats)
+SteppedFrequencyEnvelope::SteppedFrequencyEnvelope(std::shared_ptr<std::vector<FrequencyStepPhase>> phases, uint16_t stepLength, bool repeats)
+	: _phases(phases), _stepLength(stepLength), _repeats(repeats)
 {
+	_totalSteps = 0;
 	_totalLength = 0;
-	for (auto step : *this->_steps) {
-		_totalLength += step.number * this->_stepLength;
+	_totalAdjustment = 0;
+
+	for (auto phase : *this->_phases) {
+		_totalSteps += phase.number;
+		_totalLength += phase.number * _stepLength;
+		_totalAdjustment += (phase.number * phase.adjustment);
 	}
 
+	debug_log("audio_driver: SteppedFrequencyEnvelope: totalSteps=%d, totalAdjustment=%d\n\r", this->_totalSteps, this->_totalAdjustment);
 	debug_log("audio_driver: SteppedFrequencyEnvelope: stepLength=%d, repeats=%d, totalLength=%d\n\r", this->_stepLength, this->_repeats, _totalLength);
 }
 
 uint16_t SteppedFrequencyEnvelope::getFrequency(uint16_t baseFrequency, uint16_t elapsed, long duration) {
 	// returns frequency for the given elapsed time
 	// a duration of -1 means we're playing forever
-	
-	return baseFrequency;
+	int currentStep = (elapsed / this->_stepLength) % this->_totalSteps;
+	int loopCount = elapsed / this->_totalLength;
+
+	if (!_repeats && loopCount > 0) {
+		// we're not repeating and we've finished the envelope
+		return baseFrequency + this->_totalAdjustment;
+	}
+
+	// otherwise we need to calculate the frequency
+	int frequency = baseFrequency;
+
+	// TODO cumulative adjustment (using loopCount * _totalAdjustment)
+
+	for (auto phase : *this->_phases) {
+		if (currentStep < phase.number) {
+			frequency += (currentStep * phase.adjustment);
+			break;
+		}
+
+		currentStep -= phase.number;
+	}
+
+	// TODO loop frequency value as appropriate
+
+	return frequency;
 }
 
 bool SteppedFrequencyEnvelope::isFinished(uint16_t elapsed, long duration) {

--- a/video/envelopes/frequency.h
+++ b/video/envelopes/frequency.h
@@ -1,0 +1,58 @@
+//
+// Title:	        Audio Frequency Envelope support
+// Author:        	Steve Sims
+// Created:       	13/08/2023
+// Last Updated:	13/08/2023
+
+#include <memory>
+#include <vector>
+
+class FrequencyEnvelope {
+	public:
+		virtual uint16_t getFrequency(uint16_t baseFrequency, uint16_t elapsed, long duration);
+		virtual bool isFinished(uint16_t elapsed, long duration);
+};
+
+struct FrequencyStep {
+	int16_t increment;		// change of frequency per step
+	uint16_t number;		// number of steps
+};
+
+class SteppedFrequencyEnvelope : public FrequencyEnvelope {
+	public:
+		SteppedFrequencyEnvelope(std::shared_ptr<std::vector<FrequencyStep>> steps, uint16_t stepLength, bool repeats);
+		uint16_t getFrequency(uint16_t baseFrequency, uint16_t elapsed, long duration);
+		bool isFinished(uint16_t elapsed, long duration);
+	private:
+		std::shared_ptr<std::vector<FrequencyStep>> _steps;
+		long _stepLength;
+		long _totalLength;
+		bool _repeats;
+};
+
+SteppedFrequencyEnvelope::SteppedFrequencyEnvelope(std::shared_ptr<std::vector<FrequencyStep>> steps, uint16_t stepLength, bool repeats)
+	: _steps(steps), _stepLength(stepLength), _repeats(repeats)
+{
+	_totalLength = 0;
+	for (auto step : *this->_steps) {
+		_totalLength += step.number * this->_stepLength;
+	}
+
+	debug_log("audio_driver: SteppedFrequencyEnvelope: stepLength=%d, repeats=%d, totalLength=%d\n\r", this->_stepLength, this->_repeats, _totalLength);
+}
+
+uint16_t SteppedFrequencyEnvelope::getFrequency(uint16_t baseFrequency, uint16_t elapsed, long duration) {
+	// returns frequency for the given elapsed time
+	// a duration of -1 means we're playing forever
+	
+	return baseFrequency;
+}
+
+bool SteppedFrequencyEnvelope::isFinished(uint16_t elapsed, long duration) {
+	if (_repeats) {
+		// a repeating frequency envelope never finishes
+		return false;
+	}
+
+	return elapsed >= _totalLength;
+}

--- a/video/envelopes/volume.h
+++ b/video/envelopes/volume.h
@@ -1,8 +1,8 @@
 //
-// Title:	        Audio Envelope support
-// Author:        	Steve Sims
-// Created:       	06/08/2023
-// Last Updated:	06/08/2023
+// Title:			Audio Volume Envelope support
+// Author:			Steve Sims
+// Created:			06/08/2023
+// Last Updated:	13/08/2023
 
 class VolumeEnvelope {
 	public:
@@ -24,13 +24,11 @@ class ADSRVolumeEnvelope : public VolumeEnvelope {
 		word _release;
 };
 
-ADSRVolumeEnvelope::ADSRVolumeEnvelope(word attack, word decay, byte sustain, word release) {
+ADSRVolumeEnvelope::ADSRVolumeEnvelope(word attack, word decay, byte sustain, word release)
+	: _attack(attack), _decay(decay), _sustain(sustain), _release(release)
+{
 	// attack, decay, release are time values in milliseconds
 	// sustain is 0-255, centered on 127, and is the relative sustain level
-	this->_attack = attack;
-	this->_decay = decay;
-	this->_sustain = sustain;
-	this->_release = release;
 	debug_log("audio_driver: ADSRVolumeEnvelope: attack=%d, decay=%d, sustain=%d, release=%d\n\r", this->_attack, this->_decay, this->_sustain, this->_release);
 }
 

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -226,7 +226,7 @@ void setFrequencyEnvelope(byte channel, byte type) {
 				break;
 			case AUDIO_FREQUENCY_ENVELOPE_STEPPED:
 				int phaseCount = readByte_t();	if (phaseCount == -1) return;
-				byte repeats = readByte_t();	if (repeats == -1) return;
+				int control = readByte_t();		if (control == -1) return;
 				int stepLength = readWord_t();	if (stepLength == -1) return;
 				auto phases = std::make_shared<std::vector<FrequencyStepPhase>>();
 				for (int n = 0; n < phaseCount; n++) {
@@ -234,7 +234,10 @@ void setFrequencyEnvelope(byte channel, byte type) {
 					int number = readWord_t();		if (number == -1) return;
 					phases->push_back(FrequencyStepPhase { (int16_t)adjustment, number });
 				}
-				auto envelope = std::make_shared<SteppedFrequencyEnvelope>(phases, stepLength, repeats != 0);
+				bool repeats = control & AUDIO_FREQUENCY_REPEATS;
+				bool cumulative = control & AUDIO_FREQUENCY_CUMULATIVE;
+				bool restrict = control & AUDIO_FREQUENCY_RESTRICT;
+				auto envelope = std::make_shared<SteppedFrequencyEnvelope>(phases, stepLength, repeats, cumulative, restrict);
 				audio_channels[channel]->setFrequencyEnvelope(envelope);
 				break;
 		}

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -225,21 +225,17 @@ void setFrequencyEnvelope(byte channel, byte type) {
 				debug_log("vdu_sys_audio: channel %d - frequency envelope disabled\n\r", channel);
 				break;
 			case AUDIO_FREQUENCY_ENVELOPE_STEPPED:
-				int stepCount = readByte_t();	if (stepCount == -1) return;
+				int phaseCount = readByte_t();	if (phaseCount == -1) return;
 				byte repeats = readByte_t();	if (repeats == -1) return;
 				int stepLength = readWord_t();	if (stepLength == -1) return;
-				auto steps = std::make_shared<std::vector<FrequencyStep>>();
-				debug_log("vdu_sys_audio: channel %d - stepped frequency envelope, steps %d, repeats %d, step length %d\n\r", channel, stepCount, repeats, stepLength);
-				for (int n = 0; n < stepCount; n++) {
-					int increment = readWord_t();	if (increment == -1) return;
+				auto phases = std::make_shared<std::vector<FrequencyStepPhase>>();
+				for (int n = 0; n < phaseCount; n++) {
+					int adjustment = readWord_t();	if (adjustment == -1) return;
 					int number = readWord_t();		if (number == -1) return;
-					steps->push_back(FrequencyStep { (int16_t)increment, number });
+					phases->push_back(FrequencyStepPhase { (int16_t)adjustment, number });
 				}
-				debug_log("got steps\n\r");
-				auto envelope = std::make_shared<SteppedFrequencyEnvelope>(steps, stepLength, repeats != 0);
-				debug_log("got envelope\n\r");
+				auto envelope = std::make_shared<SteppedFrequencyEnvelope>(phases, stepLength, repeats != 0);
 				audio_channels[channel]->setFrequencyEnvelope(envelope);
-				debug_log("set envelope\n\r");
 				break;
 		}
 	}


### PR DESCRIPTION
Adds frequency envelope support to audio enhancements

As mentioned in #76 this extends on work done in that PR, and provides for a frequency envelope support.  A stepped frequency envelope is supported, which can be used to make frequency envelopes that are essentially compatible with those used on the BBC Micro