### PR TITLE
Buffered command support

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -140,29 +140,29 @@
 
 // Adjust operation flags
 #define ADJUST_OP_MASK			0x0F	// operation code mask
-#define ADJUST_16				0x10	// values to adjust are 16-bits values
+#define ADJUST_24BIT_OFFSETS		0x10	// offset values are 24-bit
 #define ADJUST_BUFFER_VALUE		0x20	// operand is a buffer fetched value
-#define ADJUST_MULTI_DST		0x40	// multiple destination values will be adjusted
-#define ADJUST_MULTI_SRC		0x80	// multiple source values used for adjustments
+#define ADJUST_MULTI_TARGET		0x40	// multiple target values will be adjusted
+#define ADJUST_MULTI_OPERAND	0x80	// multiple operand values used for adjustments
 
 // Conditional operation codes
-#define COND_EXISTS				0x00	// Conditional: exists (non-zero value)
-#define COND_EQUAL				0x01	// Conditional: equal
-#define COND_NOT_EQUAL			0x02	// Conditional: not equal
-#define COND_LESS				0x03	// Conditional: less than
-#define COND_GREATER			0x04	// Conditional: greater than
-#define COND_LESS_EQUAL			0x05	// Conditional: less than or equal
-#define COND_GREATER_EQUAL		0x06	// Conditional: greater than or equal
-#define COND_AND				0x07	// Conditional: AND
-#define COND_OR					0x08	// Conditional: OR
-#define COND_XOR				0x09	// Conditional: XOR
-#define COND_NOT				0x0A	// Conditional: NOT
+#define COND_EQUAL				0x00	// Conditional: equal
+#define COND_NOT_EQUAL			0x01	// Conditional: not equal
+#define COND_LESS				0x02	// Conditional: less than
+#define COND_GREATER			0x03	// Conditional: greater than
+#define COND_LESS_EQUAL			0x04	// Conditional: less than or equal
+#define COND_GREATER_EQUAL		0x05	// Conditional: greater than or equal
+#define COND_AND				0x06	// Conditional: AND
+#define COND_OR					0x07	// Conditional: OR
+#define COND_XOR				0x08	// Conditional: XOR
+// exists and not-exists are equals and not-equals with a zero value
+// #define COND_EXISTS				0x09	// Conditional: exists (non-zero value)
+// #define COND_NOT				0x0A	// Conditional: NOT exists (zero value)
 
 // Conditional operation flags
-#define COND_BASE				0x00	// value to compare is 8-bits
-#define COND_16					0x10	// value to compare is 16-bits
+#define COND_OP_MASK			0x0F	// conditional operation code mask
+#define COND_LONG_OFFSETS		0x10	// offset values are 24-bit
 #define COND_BUFFER_VALUE		0x20	// value to compare is a buffer-fetched value
-// #define COND_BUFFER_16			0x30	// value to compare is a buffer 16-bit value
 
 // Viewport definitions
 #define VIEWPORT_TEXT			0		// Text viewport

--- a/video/agon.h
+++ b/video/agon.h
@@ -44,6 +44,7 @@
 #define VDP_MODE				0x86	// Get screen dimensions
 #define VDP_RTC					0x87	// RTC
 #define VDP_KEYSTATE			0x88	// Keyboard repeat rate and LED status
+#define VDP_BUFFERED			0xA0	// Buffered commands
 #define VDP_LOGICALCOORDS		0xC0	// Switch BBC Micro style logical coords on and off
 #define VDP_LEGACYMODES			0xC1	// Switch VDP 1.03 compatible modes on and off
 #define VDP_SWITCHBUFFER		0xC3	// Double buffering control
@@ -116,6 +117,12 @@
 #define AUDIO_STATE_PLAY_LOOP	3		// Channel is in active note playing loop
 #define AUDIO_STATE_RELEASE		4		// Channel is releasing a note
 #define AUDIO_STATE_ABORT		5		// Channel is aborting a note
+
+// Buffered commands
+#define BUFFERED_WRITE			0x00	// Write to a numbered buffer
+#define BUFFERED_CALL			0x01	// Call buffered commands
+#define BUFFERED_CLEAR			0x02	// Clear buffered commands
+#define BUFFERED_ADJUST			0x03	// Adjust buffered commands
 
 // Viewport definitions
 #define VIEWPORT_TEXT			0		// Text viewport

--- a/video/agon.h
+++ b/video/agon.h
@@ -140,28 +140,26 @@
 
 // Adjust operation flags
 #define ADJUST_OP_MASK			0x0F	// operation code mask
-#define ADJUST_24BIT_OFFSETS		0x10	// offset values are 24-bit
+#define ADJUST_24BIT_OFFSETS	0x10	// offset values are 24-bit
 #define ADJUST_BUFFER_VALUE		0x20	// operand is a buffer fetched value
 #define ADJUST_MULTI_TARGET		0x40	// multiple target values will be adjusted
 #define ADJUST_MULTI_OPERAND	0x80	// multiple operand values used for adjustments
 
 // Conditional operation codes
-#define COND_EQUAL				0x00	// Conditional: equal
-#define COND_NOT_EQUAL			0x01	// Conditional: not equal
-#define COND_LESS				0x02	// Conditional: less than
-#define COND_GREATER			0x03	// Conditional: greater than
-#define COND_LESS_EQUAL			0x04	// Conditional: less than or equal
-#define COND_GREATER_EQUAL		0x05	// Conditional: greater than or equal
-#define COND_AND				0x06	// Conditional: AND
-#define COND_OR					0x07	// Conditional: OR
-#define COND_XOR				0x08	// Conditional: XOR
-// exists and not-exists are equals and not-equals with a zero value
-// #define COND_EXISTS				0x09	// Conditional: exists (non-zero value)
-// #define COND_NOT				0x0A	// Conditional: NOT exists (zero value)
+#define COND_EXISTS				0x00	// Conditional: exists (non-zero value)
+#define COND_NOT_EXISTS			0x01	// Conditional: NOT exists (zero value)
+#define COND_EQUAL				0x02	// Conditional: equal
+#define COND_NOT_EQUAL			0x03	// Conditional: not equal
+#define COND_LESS				0x04	// Conditional: less than
+#define COND_GREATER			0x05	// Conditional: greater than
+#define COND_LESS_EQUAL			0x06	// Conditional: less than or equal
+#define COND_GREATER_EQUAL		0x07	// Conditional: greater than or equal
+#define COND_AND				0x08	// Conditional: AND
+#define COND_OR					0x09	// Conditional: OR
 
 // Conditional operation flags
 #define COND_OP_MASK			0x0F	// conditional operation code mask
-#define COND_LONG_OFFSETS		0x10	// offset values are 24-bit
+#define COND_24BIT_OFFSETS		0x10	// offset values are 24-bit
 #define COND_BUFFER_VALUE		0x20	// value to compare is a buffer-fetched value
 
 // Viewport definitions

--- a/video/agon.h
+++ b/video/agon.h
@@ -125,7 +125,44 @@
 #define BUFFERED_CREATE			0x03	// Create a new empty buffer
 #define BUFFERED_SET_OUTPUT		0x04	// Set the output buffer
 #define BUFFERED_ADJUST			0x05	// Adjust buffered commands
+#define BUFFERED_CONDITIONAL	0x06	// Conditionally call a buffer
 #define BUFFERED_DEBUG_INFO		0x10	// Get debug info about a buffer
+
+// Adjust operation codes
+#define ADJUST_ADD				0x00	// Adjust: add
+#define ADJUST_ADD_CARRY		0x01	// Adjust: add with carry
+#define ADJUST_AND				0x02	// Adjust: AND
+#define ADJUST_OR				0x03	// Adjust: OR
+#define ADJUST_XOR				0x04	// Adjust: XOR
+#define ADJUST_SET				0x05	// Adjust: set new value (replace)
+#define ADJUST_NOT				0x06	// Adjust: NOT
+#define ADJUST_NEG				0x07	// Adjust: Negative
+
+// Adjust operation flags
+#define ADJUST_OP_MASK			0x0F	// operation code mask
+#define ADJUST_16				0x10	// values to adjust are 16-bits values
+#define ADJUST_BUFFER_VALUE		0x20	// operand is a buffer fetched value
+#define ADJUST_MULTI_DST		0x40	// multiple destination values will be adjusted
+#define ADJUST_MULTI_SRC		0x80	// multiple source values used for adjustments
+
+// Conditional operation codes
+#define COND_EXISTS				0x00	// Conditional: exists (non-zero value)
+#define COND_EQUAL				0x01	// Conditional: equal
+#define COND_NOT_EQUAL			0x02	// Conditional: not equal
+#define COND_LESS				0x03	// Conditional: less than
+#define COND_GREATER			0x04	// Conditional: greater than
+#define COND_LESS_EQUAL			0x05	// Conditional: less than or equal
+#define COND_GREATER_EQUAL		0x06	// Conditional: greater than or equal
+#define COND_AND				0x07	// Conditional: AND
+#define COND_OR					0x08	// Conditional: OR
+#define COND_XOR				0x09	// Conditional: XOR
+#define COND_NOT				0x0A	// Conditional: NOT
+
+// Conditional operation flags
+#define COND_BASE				0x00	// value to compare is 8-bits
+#define COND_16					0x10	// value to compare is 16-bits
+#define COND_BUFFER_VALUE		0x20	// value to compare is a buffer-fetched value
+// #define COND_BUFFER_16			0x30	// value to compare is a buffer 16-bit value
 
 // Viewport definitions
 #define VIEWPORT_TEXT			0		// Text viewport

--- a/video/agon.h
+++ b/video/agon.h
@@ -122,7 +122,10 @@
 #define BUFFERED_WRITE			0x00	// Write to a numbered buffer
 #define BUFFERED_CALL			0x01	// Call buffered commands
 #define BUFFERED_CLEAR			0x02	// Clear buffered commands
-#define BUFFERED_ADJUST			0x03	// Adjust buffered commands
+#define BUFFERED_CREATE			0x03	// Create a new empty buffer
+#define BUFFERED_SET_OUTPUT		0x04	// Set the output buffer
+#define BUFFERED_ADJUST			0x05	// Adjust buffered commands
+#define BUFFERED_DEBUG_INFO		0x10	// Get debug info about a buffer
 
 // Viewport definitions
 #define VIEWPORT_TEXT			0		// Text viewport

--- a/video/buffer_stream.h
+++ b/video/buffer_stream.h
@@ -13,6 +13,9 @@ class BufferStream : public Stream {
 		int read();
 		int peek();
 		size_t write(uint8_t b);
+		virtual bool isWritable() {
+			return false;
+		}
 
 		void rewind() {
 			bufferPosition = 0;
@@ -100,6 +103,9 @@ class WritableBufferStream : public BufferStream {
 	public:
 		WritableBufferStream(uint32_t bufferLength) : BufferStream(bufferLength), bufferWritePosition(0) {};
 		size_t write(uint8_t b);
+		bool isWritable() override {
+			return true;
+		};
 
 		void rewindWrite() {
 			bufferWritePosition = 0;

--- a/video/buffer_stream.h
+++ b/video/buffer_stream.h
@@ -1,0 +1,99 @@
+#ifndef BUFFER_STREAM_H
+#define BUFFER_STREAM_H
+
+#include <memory>
+#include <Stream.h>
+
+#include "types.h"
+
+class BufferStream : Stream {
+	public:
+		BufferStream(uint32_t bufferLength);
+		int available();
+		int read();
+		int peek();
+		size_t write(uint8_t b);
+
+		void rewind();
+
+		inline uint8_t * getBuffer() {
+			return buffer.get();
+		}
+		bool writeBuffer(uint8_t * data, uint32_t length, uint32_t offset);
+		void writeBufferByte(uint8_t data, uint32_t offset);
+		bool incrementBufferByte(uint32_t offset, int8_t by);
+	private:
+		std::unique_ptr<uint8_t[]> buffer;
+		uint32_t bufferLength;
+		uint32_t bufferPosition;
+};
+
+BufferStream::BufferStream(uint32_t bufferLength) : bufferLength(bufferLength) {
+	buffer = make_unique_psram_array<uint8_t>(bufferLength);
+	rewind();
+}
+
+int BufferStream::available() {
+	return bufferLength - bufferPosition;
+}
+
+int BufferStream::read() {
+	if (bufferPosition < bufferLength) {
+		return buffer[bufferPosition++];
+	}
+	return -1;
+}
+
+int BufferStream::peek() {
+	if (bufferPosition < bufferLength) {
+		return buffer[bufferPosition];
+	}
+	return -1;
+}
+
+void BufferStream::rewind() {
+	bufferPosition = 0;
+}
+
+size_t BufferStream::write(uint8_t b) {
+	// write is not supported
+	return 0;
+}
+
+bool BufferStream::writeBuffer(uint8_t * data, uint32_t length, uint32_t offset = 0) {
+	// TODO consider return type - we could support writing to buffer limit,
+	// and returning how many bytes were written
+	if (length + offset <= bufferLength) {
+		memcpy(buffer.get() + offset, data, length);
+		return true;
+	} else {
+		debug_log("BufferStream::writeBuffer: buffer overflow\n\r");
+		return false;
+	}
+}
+
+void BufferStream::writeBufferByte(uint8_t data, uint32_t offset = 0) {
+	if (offset < bufferLength) {
+		buffer[offset] = data;
+	}
+}
+
+// incrementBufferByte
+// accepts an offset and a value to increment by
+// returns true if value overflowed
+bool BufferStream::incrementBufferByte(uint32_t offset = 0, int8_t by = 1) {
+	if (offset < bufferLength) {
+		auto oldValue = buffer[offset];
+		buffer[offset] += by;
+
+		// check for overflow
+		if (by > 0) {
+			return buffer[offset] < oldValue;
+		} else {
+			return buffer[offset] > oldValue;
+		}
+	}
+	return false;
+}
+
+#endif // BUFFER_STREAM_H

--- a/video/buffer_stream.h
+++ b/video/buffer_stream.h
@@ -19,6 +19,9 @@ class BufferStream : Stream {
 		inline uint8_t * getBuffer() {
 			return buffer.get();
 		}
+		inline uint32_t size() {
+			return bufferLength;
+		}
 		bool writeBuffer(uint8_t * data, uint32_t length, uint32_t offset);
 		void writeBufferByte(uint8_t data, uint32_t offset);
 		bool incrementBufferByte(uint32_t offset, int8_t by);

--- a/video/multi_buffer_stream.h
+++ b/video/multi_buffer_stream.h
@@ -1,0 +1,64 @@
+#ifndef MULTI_BUFFER_STREAM_H
+#define MULTI_BUFFER_STREAM_H
+
+#include <memory>
+#include <vector>
+#include <Stream.h>
+
+#include "buffer_stream.h"
+#include "types.h"
+
+class MultiBufferStream : Stream {
+	public:
+		MultiBufferStream(std::vector<std::shared_ptr<BufferStream>, psram_allocator<std::shared_ptr<BufferStream>>> buffers);
+		int available();
+		int read();
+		int peek();
+		size_t write(uint8_t b);
+	private:
+		std::vector<std::shared_ptr<BufferStream>, psram_allocator<std::shared_ptr<BufferStream>>> buffers;
+		std::shared_ptr<BufferStream> getBuffer();
+};
+
+MultiBufferStream::MultiBufferStream(std::vector<std::shared_ptr<BufferStream>, psram_allocator<std::shared_ptr<BufferStream>>> buffers) : buffers(buffers) {
+	// rewind all buffers, in case they've been used before
+	for (auto buffer : buffers) {
+		buffer->rewind();
+	}
+}
+
+int MultiBufferStream::available() {
+	auto buffer = getBuffer();
+	if (buffer) {
+		return buffer->available();
+	}
+	return 0;
+}
+
+int MultiBufferStream::read() {
+	auto buffer = getBuffer();
+	return buffer->read();
+}
+
+int MultiBufferStream::peek() {
+	auto buffer = getBuffer();
+	return buffer->peek();
+}
+
+size_t MultiBufferStream::write(uint8_t b) {
+	// write is not supported
+	return 0;
+}
+
+std::shared_ptr<BufferStream> MultiBufferStream::getBuffer() {
+	// iterate thru buffers until we find one that has data
+	for (auto buffer : buffers) {
+		bool available = buffer->available();
+		if (available) {
+			return buffer;
+		}
+	}
+	return nullptr;
+}
+
+#endif // MULTI_BUFFER_STREAM_H

--- a/video/multi_buffer_stream.h
+++ b/video/multi_buffer_stream.h
@@ -8,7 +8,7 @@
 #include "buffer_stream.h"
 #include "types.h"
 
-class MultiBufferStream : Stream {
+class MultiBufferStream : public Stream {
 	public:
 		MultiBufferStream(std::vector<std::shared_ptr<BufferStream>, psram_allocator<std::shared_ptr<BufferStream>>> buffers);
 		int available();

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -1,0 +1,107 @@
+#ifndef VDU_BUFFERED_H
+#define VDU_BUFFERED_H
+
+#include <memory>
+#include <vector>
+#include <unordered_map>
+
+#include "agon.h"
+#include "buffer_stream.h"
+#include "multi_buffer_stream.h"
+#include "types.h"
+
+std::unordered_map<uint8_t, std::vector<std::shared_ptr<BufferStream>, psram_allocator<std::shared_ptr<BufferStream>>>> buffers;
+
+// VDU 23, 0, &A0, bufferId, command: Buffered command support
+//
+void VDUStreamProcessor::vdu_sys_buffered() {
+	auto bufferId = readByte_t();
+	auto command = readByte_t();
+
+	switch (command) {
+		case BUFFERED_WRITE: {
+			bufferWrite(bufferId);
+		}	break;
+		case BUFFERED_CALL: {
+			bufferCall(bufferId);
+		}	break;
+		case BUFFERED_CLEAR: {
+			bufferClear(bufferId);
+		}	break;
+		case BUFFERED_ADJUST: {
+			bufferAdjust(bufferId);
+		}	break;
+	}
+}
+
+// VDU 23, 0, &A0, bufferId, 0, length; data...: store stream into buffer
+// This adds a new stream to the given bufferId
+// allowing a single bufferId to store multiple streams of data
+//
+void VDUStreamProcessor::bufferWrite(uint8_t bufferId) {
+	auto length = readWord_t();
+	auto bufferStream = make_shared_psram<BufferStream>(length);
+
+	debug_log("bufferWrite: storing stream into buffer %d, length %d\n\r", bufferId, length);
+
+	for (auto i = 0; i < length; i++) {
+		auto data = readByte_b();
+		bufferStream->writeBufferByte(data, i);
+	}
+
+	buffers[bufferId].push_back(std::move(bufferStream));
+	debug_log("bufferWrite: stored stream in buffer %d, length %d, %d streams stored\n\r", bufferId, length, buffers[bufferId].size());
+}
+
+// VDU 23, 0, &A0, bufferId, 1: Call buffer
+// Processes all commands from the streams stored against the given bufferId
+//
+void VDUStreamProcessor::bufferCall(uint8_t bufferId) {
+	debug_log("bufferCall: buffer %d\n\r", bufferId);
+	if (buffers.find(bufferId) != buffers.end()) {
+		auto streams = buffers[bufferId];
+		auto multiBufferStream = make_shared_psram<MultiBufferStream>(streams);
+		auto streamProcessor = make_unique_psram<VDUStreamProcessor>((Stream *)multiBufferStream.get());
+		streamProcessor->processAllAvailable();
+	} else {
+		debug_log("bufferCall: buffer %d not found\n\r", bufferId);
+	}
+}
+
+// VDU 23, 0, &A0, bufferId, 2: Clear buffer
+// Removes all streams stored against the given bufferId
+//
+void VDUStreamProcessor::bufferClear(uint8_t bufferId) {
+	debug_log("bufferClear: buffer %d\n\r", bufferId);
+	if (buffers.find(bufferId) != buffers.end()) {
+		buffers.erase(bufferId);
+	} else {
+		debug_log("bufferClear: buffer %d not found\n\r", bufferId);
+	}
+}
+
+// VDU 23, 0, &A0, bufferId, 3: Adjust buffer
+// TODO...
+//
+void VDUStreamProcessor::bufferAdjust(uint8_t bufferId) {
+	// TODO implement commands to adjust buffer contents
+	// ideas include:
+	// overwrite byte
+	// overwrite multiple bytes
+	// insert byte(s)
+	// increment by amount
+	// increment with carry
+	// other maths/logic operations on bytes within buffer
+	// copy bytes from one buffer to another
+
+	// then there is things like conditional call
+	//   based on a byte value within a given buffer
+	//   consider different comparisons (==, !=, <, >, <=, >=)
+	//   and comparisons with words, longs, etc
+	// possibly jump to a given or relative buffer position
+	//   altho it may be more sensible to just encourage calling a different buffer
+
+	// there _may_ be value in increasing the size of our bufferId to 16bits
+}
+
+#endif // VDU_BUFFERED_H

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -141,13 +141,18 @@ void VDUStreamProcessor::setOutputStream(uint16_t bufferId) {
 		return;
 	}
 	// bufferId of 0 resets output buffer to it's original value
-	// which will usually be ethe z80 serial port
+	// which will usually be the z80 serial port
 	if (bufferId == 0) {
 		outputStream = originalOutputStream;
 		return;
 	}
 	if (buffers.find(bufferId) != buffers.end()) {
-		outputStream = buffers[bufferId][0];
+		auto output = buffers[bufferId][0];
+		if (output->isWritable()) {
+			outputStream = output;
+		} else {
+			debug_log("setOutputStream: buffer %d is not writable\n\r", bufferId);
+		}
 	} else {
 		debug_log("setOutputStream: buffer %d not found\n\r", bufferId);
 	}

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -10,8 +10,8 @@ class VDUStreamProcessor {
 	public:
 		VDUStreamProcessor(std::shared_ptr<Stream> inputStream, std::shared_ptr<Stream> outputStream) :
 			inputStream(inputStream), outputStream(outputStream), originalOutputStream(outputStream) {}
-		VDUStreamProcessor(Stream *inputStream) :
-			inputStream(std::shared_ptr<Stream>(inputStream)), outputStream(inputStream), originalOutputStream(inputStream) {}
+		VDUStreamProcessor(Stream *input) :
+			inputStream(std::shared_ptr<Stream>(input)), outputStream(inputStream), originalOutputStream(inputStream) {}
 		inline bool byteAvailable() {
 			return inputStream->available() > 0;
 		}

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -73,10 +73,10 @@ class VDUStreamProcessor {
 		void receiveBitmap(uint8_t cmd, uint16_t width, uint16_t height);
 
 		void vdu_sys_buffered();
-		void bufferWrite(uint8_t bufferId);
-		void bufferCall(uint8_t bufferId);
-		void bufferClear(uint8_t bufferId);
-		void bufferAdjust(uint8_t bufferId);
+		void bufferWrite(uint16_t bufferId);
+		void bufferCall(uint16_t bufferId);
+		void bufferClear(uint16_t bufferId);
+		void bufferAdjust(uint16_t bufferId);
 };
 
 // Read an unsigned byte from the serial port, with a timeout

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -88,6 +88,7 @@ class VDUStreamProcessor {
 		uint16_t getBufferByte(uint16_t bufferId, uint32_t offset);
 		bool setBufferByte(uint8_t value, uint16_t bufferId, uint32_t offset);
 		void bufferAdjust(uint16_t bufferId);
+		void bufferConditionalCall(uint16_t bufferId);
 };
 
 // Read an unsigned byte from the serial port, with a timeout

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -71,6 +71,12 @@ class VDUStreamProcessor {
 
 		void vdu_sys_sprites(void);
 		void receiveBitmap(uint8_t cmd, uint16_t width, uint16_t height);
+
+		void vdu_sys_buffered();
+		void bufferWrite(uint8_t bufferId);
+		void bufferCall(uint8_t bufferId);
+		void bufferClear(uint8_t bufferId);
+		void bufferAdjust(uint8_t bufferId);
 };
 
 // Read an unsigned byte from the serial port, with a timeout

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -85,6 +85,8 @@ class VDUStreamProcessor {
 		void bufferClear(uint16_t bufferId);
 		void bufferCreate(uint16_t bufferId);
 		void setOutputStream(uint16_t bufferId);
+		uint16_t getBufferByte(uint16_t bufferId, uint32_t offset);
+		bool setBufferByte(uint8_t value, uint16_t bufferId, uint32_t offset);
 		void bufferAdjust(uint16_t bufferId);
 };
 

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -117,7 +117,7 @@ void VDUStreamProcessor::vdu_sys_video() {
 		case VDP_KEYSTATE: {			// VDU 23, 0, &88, repeatRate; repeatDelay; status
 			vdu_sys_keystate();
 		}	break;
-		case VDP_BUFFERED: {			// VDU 23, 0, &A0, bufferId, command, <args>
+		case VDP_BUFFERED: {			// VDU 23, 0, &A0, bufferId; command, <args>
 			vdu_sys_buffered();
 		}	break;
 		case VDP_LOGICALCOORDS: {		// VDU 23, 0, &C0, n

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -9,8 +9,8 @@
 #include "cursor.h"
 #include "graphics.h"
 #include "vdu_audio.h"
+#include "vdu_buffered.h"
 #include "vdu_sprites.h"
-#include "buffer_stream.h"
 
 extern void switchTerminalMode();				// Switch to terminal mode
 
@@ -58,18 +58,6 @@ void VDUStreamProcessor::vdu_sys() {
 					enableCursor((bool) b);
 				}
 			}	break;
-
-			case 0x02: {
-				// experimental buffer thing
-				auto expStream = make_unique_psram<BufferStream>(15);
-				auto expBuffer = expStream->getBuffer();
-				expStream->writeBuffer((uint8_t *)"Hello world!\n\r", 14);
-				expStream->writeBufferByte(0x07, 14);
-				expStream->incrementBufferByte(6, -32);	// capitalise W
-				auto expProcessor = make_unique_psram<VDUStreamProcessor>((Stream *)expStream.get());
-				expProcessor->processAllAvailable();
-			}	break;
-
 			case 0x07: {					// VDU 23, 7
 				vdu_sys_scroll();			// Scroll 
 			}	break;
@@ -128,6 +116,9 @@ void VDUStreamProcessor::vdu_sys_video() {
 		}	break;
 		case VDP_KEYSTATE: {			// VDU 23, 0, &88, repeatRate; repeatDelay; status
 			vdu_sys_keystate();
+		}	break;
+		case VDP_BUFFERED: {			// VDU 23, 0, &A0, bufferId, command, <args>
+			vdu_sys_buffered();
 		}	break;
 		case VDP_LOGICALCOORDS: {		// VDU 23, 0, &C0, n
 			auto b = readByte_t();		// Set logical coord mode

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -10,6 +10,7 @@
 #include "graphics.h"
 #include "vdu_audio.h"
 #include "vdu_sprites.h"
+#include "buffer_stream.h"
 
 extern void switchTerminalMode();				// Switch to terminal mode
 
@@ -57,6 +58,18 @@ void VDUStreamProcessor::vdu_sys() {
 					enableCursor((bool) b);
 				}
 			}	break;
+
+			case 0x02: {
+				// experimental buffer thing
+				auto expStream = make_unique_psram<BufferStream>(15);
+				auto expBuffer = expStream->getBuffer();
+				expStream->writeBuffer((uint8_t *)"Hello world!\n\r", 14);
+				expStream->writeBufferByte(0x07, 14);
+				expStream->incrementBufferByte(6, -32);	// capitalise W
+				auto expProcessor = make_unique_psram<VDUStreamProcessor>((Stream *)expStream.get());
+				expProcessor->processAllAvailable();
+			}	break;
+
 			case 0x07: {					// VDU 23, 7
 				vdu_sys_scroll();			// Scroll 
 			}	break;


### PR DESCRIPTION
Adds support for buffered VDU commands

This is achieved thru `VDU 23, 0, &A0, bufferId; command, <args>`

There are commands to write a stream to a given buffer ID, "call" the VDU stream with a given buffer ID (send it to a VDU stream processor), clear a buffer ID, and to adjust the contents of a buffer.

This system allows for multiple streams to be stored against a given buffer ID. This allows for data to be sent over in multiple packets, of variable size. A bitmap or sound sample can therefore be sent over in multiple packets, rather than having to be sent over in a single data packet. When a stream is written to a buffer ID it is retained, and is not cleared after the buffer has been "called". Therefore if your intent is to use this functionality purely for packeted comms with the VDP you will need to explicitly clear a buffer after using it.

Commands are also present to allow for adjusting values within buffers, conditionally calling buffers (if conditions are met) and allowing data packets that would otherwise have been sent from the VDP to the eZ80 to be captured into a buffer.  These _essentially_ allow for reasonably complex functions to be able to be run on the VDP.

Another PR will come soon that provides documentation and examples for this command set.  (Some limited documentation is already present in the code.)