### PR TITLE
fix compiler warnings

### DIFF
--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -80,7 +80,7 @@ void init_audio() {
 // Channel enabled?
 //
 bool channelEnabled(uint8_t channel) {
-	return channel >= 0 && channel < MAX_AUDIO_CHANNELS && audio_channels[channel];
+	return channel < MAX_AUDIO_CHANNELS && audio_channels[channel];
 }
 
 // Play a note
@@ -130,7 +130,7 @@ void setWaveform(uint8_t channel, int8_t waveformType) {
 //
 uint8_t clearSample(uint8_t sampleIndex) {
 	debug_log("clearSample: sample %d\n\r", sampleIndex);
-	if (sampleIndex >= 0 && sampleIndex < MAX_AUDIO_SAMPLES) {
+	if (sampleIndex < MAX_AUDIO_SAMPLES) {
 		if (samples.find(sampleIndex) == samples.end()) {
 			debug_log("clearSample: sample %d not found\n\r", sampleIndex);
 			return 0;

--- a/video/agon_screen.h
+++ b/video/agon_screen.h
@@ -96,7 +96,7 @@ bool updateVGAController(uint8_t colours) {
 // - 1: Invalid # of colours
 // - 2: Not enough memory for mode
 //
-int8_t change_resolution(uint8_t colours, char * modeLine, bool doubleBuffered = false) {
+int8_t change_resolution(uint8_t colours, const char * modeLine, bool doubleBuffered = false) {
 	if (!updateVGAController(colours)) {			// If we can't update the controller then
 		return 1;									// Return the error
 	}

--- a/video/audio_channel.h
+++ b/video/audio_channel.h
@@ -135,8 +135,8 @@ void audio_channel::setWaveform(int8_t waveformType, std::shared_ptr<audio_chann
 		default:
 			// negative values indicate a sample number
 			if (waveformType < 0) {
-				int8_t sampleNum = -waveformType - 1;
-				if (sampleNum >= 0 && sampleNum < MAX_AUDIO_SAMPLES) {
+				uint8_t sampleNum = -waveformType - 1;
+				if (sampleNum < MAX_AUDIO_SAMPLES) {
 					debug_log("audio_driver: using sample %d for waveform (%d)\n\r", waveformType, sampleNum);
 					if (samples.find(sampleNum) != samples.end()) {
 						auto sample = samples.at(sampleNum);

--- a/video/envelopes/frequency.h
+++ b/video/envelopes/frequency.h
@@ -66,7 +66,7 @@ uint16_t SteppedFrequencyEnvelope::getFrequency(uint16_t baseFrequency, uint32_t
 	}
 
 	// otherwise we need to calculate the frequency
-	auto frequency = baseFrequency;
+	int32_t frequency = baseFrequency;
 
 	if (_cumulative) {
 		frequency += (loopCount * _totalAdjustment);

--- a/video/envelopes/volume.h
+++ b/video/envelopes/volume.h
@@ -51,7 +51,7 @@ uint8_t ADSRVolumeEnvelope::getVolume(uint8_t baseVolume, uint32_t elapsed, int3
 		return map(phaseTime, 0, this->_decay, baseVolume, sustainVolume);
 	}
 	phaseTime -= this->_decay;
-	auto sustainDuration = duration < 0 ? elapsed : duration - (this->_attack + this->_decay);
+	int32_t sustainDuration = duration < 0 ? elapsed : duration - (this->_attack + this->_decay);
 	if (sustainDuration < 0) sustainDuration = 0;
 	if (phaseTime < sustainDuration) {
 		return sustainVolume;

--- a/video/graphics.h
+++ b/video/graphics.h
@@ -57,7 +57,7 @@ char getScreenChar(uint16_t px, uint16_t py) {
 
 	// Do some bounds checking first
 	//
-	if (px < 0 || py < 0 || px >= canvasW - 8 || py >= canvasH - 8) {
+	if (px >= canvasW - 8 || py >= canvasH - 8) {
 		return 0;
 	}
 
@@ -76,7 +76,7 @@ char getScreenChar(uint16_t px, uint16_t py) {
 	//
 	// Finally try and match with the character set array
 	//
-	for (uint8_t i = 32; i <= 255; i++) {
+	for (auto i = 32; i <= 255; i++) {
 		if (cmpChar(charData, &fabgl::FONT_AGON_DATA[i * 8], 8)) {	
 			return i;		
 		}
@@ -164,7 +164,7 @@ fabgl::PaintOptions getPaintOptions(uint8_t mode, fabgl::PaintOptions priorPaint
 void setTextColour(uint8_t colour) {
 	uint8_t c = palette[colour % getVGAColourDepth()];
 
-	if (colour >= 0 && colour < 64) {
+	if (colour < 64) {
 		tfg = colourLookup[c];
 		debug_log("vdu_colour: tfg %d = %02X : %02X,%02X,%02X\n\r", colour, c, tfg.R, tfg.G, tfg.B);
 	}
@@ -182,8 +182,8 @@ void setTextColour(uint8_t colour) {
 void setGraphicsColour(uint8_t mode, uint8_t colour) {
 	uint8_t c = palette[colour % getVGAColourDepth()];
 
-	if (mode >= 0 && mode <= 6) {
-		if (colour >= 0 && colour < 64) {
+	if (mode <= 6) {
+		if (colour < 64) {
 			gfg = colourLookup[c];
 			debug_log("vdu_gcol: mode %d, gfg %d = %02X : %02X,%02X,%02X\n\r", mode, colour, c, gfg.R, gfg.G, gfg.B);
 		}

--- a/video/sprites.h
+++ b/video/sprites.h
@@ -48,7 +48,7 @@ void drawBitmap(uint16_t x, uint16_t y) {
 }
 
 void resetBitmaps() {
-	for (uint8_t n = 0; n < MAX_BITMAPS; n++) {
+	for (auto n = 0; n < MAX_BITMAPS; n++) {
 		clearBitmap(n);
 	}
 	waitPlotCompletion();
@@ -142,7 +142,7 @@ void refreshSprites() {
 }
 
 void resetSprites() {
-	for (uint8_t n = 0; n < MAX_SPRITES; n++) {
+	for (auto n = 0; n < MAX_SPRITES; n++) {
 		clearSpriteFrames(n);
 	}
 	waitPlotCompletion();

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -82,6 +82,7 @@ void VDUStreamProcessor::vdu(uint8_t c) {
 			break;
 		case 0x1D:	// VDU_29
 			vdu_origin();
+			break;
 		case 0x1E:	// Move cursor to top left of the viewport
 			cursorHome();
 			break;

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -142,7 +142,7 @@ void VDUStreamProcessor::sendAudioStatus(uint8_t channel, uint8_t status) {
 //
 uint8_t VDUStreamProcessor::loadSample(uint8_t sampleIndex, uint32_t length) {
 	debug_log("free mem: %d\n\r", heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
-	if (sampleIndex >= 0 && sampleIndex < MAX_AUDIO_SAMPLES) {
+	if (sampleIndex < MAX_AUDIO_SAMPLES) {
 		debug_log("loadSample: sample %d - length %d\n\r", sampleIndex, length);
 		// Clear out existing sample
 		clearSample(sampleIndex);

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -31,8 +31,8 @@ class VDUStreamProcessor {
 		Stream * stream;
 
 		int16_t readByte_t(uint16_t timeout);
-		uint32_t readWord_t(uint16_t timeout);
-		uint32_t read24_t(uint16_t timeout);
+		int32_t readWord_t(uint16_t timeout);
+		int32_t read24_t(uint16_t timeout);
 		uint8_t readByte_b();
 		uint32_t readLong_b();
 		void discardBytes(uint32_t length);
@@ -92,7 +92,7 @@ int16_t VDUStreamProcessor::readByte_t(uint16_t timeout = COMMS_TIMEOUT) {
 // Returns:
 // - Word value (0 to 65535) if 2 bytes read, otherwise -1
 //
-uint32_t VDUStreamProcessor::readWord_t(uint16_t timeout = COMMS_TIMEOUT) {
+int32_t VDUStreamProcessor::readWord_t(uint16_t timeout = COMMS_TIMEOUT) {
 	auto l = readByte_t(timeout);
 	if (l >= 0) {
 		auto h = readByte_t(timeout);
@@ -107,7 +107,7 @@ uint32_t VDUStreamProcessor::readWord_t(uint16_t timeout = COMMS_TIMEOUT) {
 // Returns:
 // - Value (0 to 16777215) if 3 bytes read, otherwise -1
 //
-uint32_t VDUStreamProcessor::read24_t(uint16_t timeout = COMMS_TIMEOUT) {
+int32_t VDUStreamProcessor::read24_t(uint16_t timeout = COMMS_TIMEOUT) {
 	auto l = readByte_t(timeout);
 	if (l >= 0) {
 		auto m = readByte_t(timeout);

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -159,8 +159,8 @@ void VDUStreamProcessor::vdu_sys_video_kblayout() {
 //
 void VDUStreamProcessor::sendCursorPosition() {
 	uint8_t packet[] = {
-		textCursor.X / fontW,
-		textCursor.Y / fontH,
+		(uint8_t) (textCursor.X / fontW),
+		(uint8_t) (textCursor.Y / fontH),
 	};
 	send_packet(PACKET_CURSOR, sizeof packet, packet);	
 }
@@ -195,14 +195,14 @@ void VDUStreamProcessor::sendScreenPixel(uint16_t x, uint16_t y) {
 //
 void VDUStreamProcessor::sendTime() {
 	uint8_t packet[] = {
-		rtc.getYear() - EPOCH_YEAR,			// 0 - 255
-		rtc.getMonth(),						// 0 - 11
-		rtc.getDay(),						// 1 - 31
-		rtc.getDayofYear(),					// 0 - 365
-		rtc.getDayofWeek(),					// 0 - 6
-		rtc.getHour(true),					// 0 - 23
-		rtc.getMinute(),					// 0 - 59
-		rtc.getSecond(),					// 0 - 59
+		(uint8_t) (rtc.getYear() - EPOCH_YEAR),	// 0 - 255
+		(uint8_t) rtc.getMonth(),			// 0 - 11
+		(uint8_t) rtc.getDay(),				// 1 - 31
+		rtc.getDayofYear(),		// 0 - 365 - TODO this is a bug as it won't fit in 8 bits
+		(uint8_t) rtc.getDayofWeek(),		// 0 - 6
+		(uint8_t) rtc.getHour(true),		// 0 - 23
+		(uint8_t) rtc.getMinute(),			// 0 - 59
+		(uint8_t) rtc.getSecond(),			// 0 - 59
 	};
 	send_packet(PACKET_RTC, sizeof packet, packet);
 }
@@ -211,12 +211,12 @@ void VDUStreamProcessor::sendTime() {
 //
 void VDUStreamProcessor::sendModeInformation() {
 	uint8_t packet[] = {
-		canvasW & 0xFF,						// Width in pixels (L)
-		(canvasW >> 8) & 0xFF,				// Width in pixels (H)
-		canvasH & 0xFF,						// Height in pixels (L)
-		(canvasH >> 8) & 0xFF,				// Height in pixels (H)
-		canvasW / fontW,					// Width in characters (byte)
-		canvasH / fontH,					// Height in characters (byte)
+		(uint8_t) (canvasW & 0xFF),			// Width in pixels (L)
+		(uint8_t) ((canvasW >> 8) & 0xFF),	// Width in pixels (H)
+		(uint8_t) (canvasH & 0xFF),			// Height in pixels (L)
+		(uint8_t) ((canvasH >> 8) & 0xFF),	// Height in pixels (H)
+		(uint8_t) (canvasW / fontW),		// Width in characters (byte)
+		(uint8_t) (canvasH / fontH),		// Height in characters (byte)
 		getVGAColourDepth(),				// Colour depth
 		videoMode,							// The video mode number
 	};
@@ -255,10 +255,10 @@ void VDUStreamProcessor::sendKeyboardState() {
 	uint8_t		ledState;
 	getKeyboardState(&delay, &rate, &ledState);
 	uint8_t		packet[] = {
-		delay & 0xFF,
-		(delay >> 8) & 0xFF,
-		rate & 0xFF,
-		(rate >> 8) & 0xFF,
+		(uint8_t) (delay & 0xFF),
+		(uint8_t) ((delay >> 8) & 0xFF),
+		(uint8_t) (rate & 0xFF),
+		(uint8_t) ((rate >> 8) & 0xFF),
 		ledState
 	};
 	send_packet(PACKET_KEYSTATE, sizeof packet, packet);

--- a/video/viewport.h
+++ b/video/viewport.h
@@ -99,7 +99,7 @@ bool setTextViewport(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2) {
 	if (x2 >= canvasW) x2 = canvasW - 1;
 	if (y2 >= canvasH) y2 = canvasH - 1;
 
-	if (x1 >= 0 && y1 >= 0 && x2 > x1 && y2 > y1) {
+	if (x2 > x1 && y2 > y1) {
 		textViewport = Rect(x1, y1, x2, y2);
 		useViewports = true;
 		return true;


### PR DESCRIPTION
fixes all compiler warnings by either removing unnecessary checks, fixing types to be more appropriate, and fixing a few minor bugs that these warnings were telling us about

one warning remains, which is to do with the RTC day of year value in our RTC VDP info packet.  this warning reflects a bug as we’re trying to send a day of year (range 0-365) in a single byte (range 0-255) which doesn’t fit.  (see #91 )