### PR TITLE
Buffer commands improvements

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -129,14 +129,14 @@
 #define BUFFERED_DEBUG_INFO		0x10	// Get debug info about a buffer
 
 // Adjust operation codes
-#define ADJUST_ADD				0x00	// Adjust: add
-#define ADJUST_ADD_CARRY		0x01	// Adjust: add with carry
-#define ADJUST_AND				0x02	// Adjust: AND
-#define ADJUST_OR				0x03	// Adjust: OR
-#define ADJUST_XOR				0x04	// Adjust: XOR
-#define ADJUST_SET				0x05	// Adjust: set new value (replace)
-#define ADJUST_NOT				0x06	// Adjust: NOT
-#define ADJUST_NEG				0x07	// Adjust: Negative
+#define ADJUST_NOT				0x00	// Adjust: NOT
+#define ADJUST_NEG				0x01	// Adjust: Negative
+#define ADJUST_SET				0x02	// Adjust: set new value (replace)
+#define ADJUST_ADD				0x03	// Adjust: add
+#define ADJUST_ADD_CARRY		0x04	// Adjust: add with carry
+#define ADJUST_AND				0x05	// Adjust: AND
+#define ADJUST_OR				0x06	// Adjust: OR
+#define ADJUST_XOR				0x07	// Adjust: XOR
 
 // Adjust operation flags
 #define ADJUST_OP_MASK			0x0F	// operation code mask

--- a/video/multi_buffer_stream.h
+++ b/video/multi_buffer_stream.h
@@ -15,6 +15,7 @@ class MultiBufferStream : public Stream {
 		int read();
 		int peek();
 		size_t write(uint8_t b);
+		void rewind();
 	private:
 		std::vector<std::shared_ptr<BufferStream>, psram_allocator<std::shared_ptr<BufferStream>>> buffers;
 		std::shared_ptr<BufferStream> getBuffer();
@@ -23,10 +24,7 @@ class MultiBufferStream : public Stream {
 
 MultiBufferStream::MultiBufferStream(std::vector<std::shared_ptr<BufferStream>, psram_allocator<std::shared_ptr<BufferStream>>> buffers) : buffers(buffers) {
 	// rewind all buffers, in case they've been used before
-	for (auto buffer : buffers) {
-		buffer->rewind();
-	}
-	currentBufferIndex = 0;
+	rewind();
 }
 
 int MultiBufferStream::available() {
@@ -50,6 +48,13 @@ int MultiBufferStream::peek() {
 size_t MultiBufferStream::write(uint8_t b) {
 	// write is not supported
 	return 0;
+}
+
+void MultiBufferStream::rewind() {
+	for (auto buffer : buffers) {
+		buffer->rewind();
+	}
+	currentBufferIndex = 0;
 }
 
 inline std::shared_ptr<BufferStream> MultiBufferStream::getBuffer() {

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -8,8 +8,8 @@
 
 class VDUStreamProcessor {
 	public:
-		VDUStreamProcessor(std::shared_ptr<Stream> inputStream, std::shared_ptr<Stream> outputStream) :
-			inputStream(inputStream), outputStream(outputStream), originalOutputStream(outputStream) {}
+		VDUStreamProcessor(std::shared_ptr<Stream> inputStream, std::shared_ptr<Stream> outputStream, uint16_t bufferId) :
+			inputStream(inputStream), outputStream(outputStream), originalOutputStream(outputStream), id(bufferId) {}
 		VDUStreamProcessor(Stream *input) :
 			inputStream(std::shared_ptr<Stream>(input)), outputStream(inputStream), originalOutputStream(inputStream) {}
 		inline bool byteAvailable() {
@@ -32,6 +32,8 @@ class VDUStreamProcessor {
 
 		void wait_eZ80();
 		void sendModeInformation();
+
+		uint16_t id = 65535;
 	private:
 		std::shared_ptr<Stream> inputStream;
 		std::shared_ptr<Stream> outputStream;
@@ -160,9 +162,8 @@ uint32_t VDUStreamProcessor::readLong_b() {
 // Discard a given number of bytes from input stream
 //
 void VDUStreamProcessor::discardBytes(uint32_t length) {
-	while (length > 0) {
-		readByte_t(0);
-		length--;
+	for (uint32_t i = 0; i < length; i++) {
+		readByte_b();
 	}
 }
 


### PR DESCRIPTION
In writing documentation for the new buffered commands VDU calls, some adjustments and improvements have been made.

The first changes made were to the numbering of the "adjust" command operations.  the issue was primarily with the numbering of the "not" and "negate" instructions.  they are the only two operations that don't require a separate operand, but they had been placed them at the end of the instruction list.  with the current set of operations that's potentially OK, but there are several new adjust instructions that we may wish to add in the future (multiply, shift, etc) - any/all new operations will want a separate operand.

the renumbering in this PR means that it's the first two instructions that _don't_ require a separate operand (rather than the last two).  this (now) mirrors the "conditional call" command.  this renumbering will make it more straightforward to add in new operations in the future, and makes the documentation slightly simpler.

since all the buffered command operations are new, and the documentation has not yet been published, this feels like a safe thing to do right now, rather than living with the earlier "mistake".  (to be honest, I'd already _half_ realised this when I raised the PR with buffered commands, as the logic between "conditional call" and "adjust" was inconsistent.)

This PR also improves how "call" (and "conditional call") operates when a buffer is calling itself.  When this is detected, the VDU input stream is now just rewound to the beginning, rather than a new instance of the VDU command processor being created.

Finally there is a small bug fix for the `discardBytes` call.


The documentation for the buffered commands API follows the numbering and behaviour of the API as in this PR.
