### PR TITLE
Optimize readLong_b to read 32bit at once from the serial buffer.

### DIFF
--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -149,12 +149,10 @@ uint8_t VDUStreamProcessor::readByte_b() {
 // Read an unsigned word from the serial port (blocking)
 //
 uint32_t VDUStreamProcessor::readLong_b() {
-  uint32_t temp;
-  temp  =  readByte_b();		// LSB;
-  temp |= (readByte_b() << 8);
-  temp |= (readByte_b() << 16);
-  temp |= (readByte_b() << 24);
-  return temp;
+	uint32_t result;
+	while(inputStream->available() < sizeof(uint32_t));
+	inputStream->readBytes((uint8_t*)&result, sizeof(uint32_t));
+  	return result;
 }
 
 // Discard a given number of bytes from input stream


### PR DESCRIPTION
This small change does optimize the upload speed from the ez80 to the VDP. The attached benchmark shows upload speed of 227kbits with the current code and 749kbits with my change. You can also "feel" the difference if you start games like rokky.

[agon-bench.zip](https://github.com/breakintoprogram/agon-vdp/files/12677182/agon-bench.zip)
