### PR TITLE
Ensure switch-buffer command always waits for vsync

### DIFF
--- a/video/agon_screen.h
+++ b/video/agon_screen.h
@@ -132,10 +132,13 @@ inline bool isDoubleBuffered() {
 }
 
 // Swap to other buffer if we're in a double-buffered mode
+// Always waits for VSYNC
 //
 void switchBuffer() {
 	if (isDoubleBuffered()) {
 		canvas->swapBuffers();
+	} else {
+		waitPlotCompletion(true);
 	}
 }
 


### PR DESCRIPTION
This modification ensures we have a VDP-side "wait for VSYNC" command.

Owing to how double-buffered screen modes work, the existing "switch buffer" command _effectively_ is already a "wait for VSYNC" command, but one that will only work on double-buffered screen modes.

This change ensures that for non-double-buffered modes the command will maintain the "wait for VSYNC" functionality.

Providing the ability for a command stream on the VDP to wait for VSYNC is a useful function for buffered commands.