### PR TITLE
Non-blocking reads

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -26,7 +26,7 @@
 #define UART_RTS				13		// The ESP32 RTS pin (eZ80 CTS)
 #define UART_CTS	 			14		// The ESP32 CTS pin (eZ80 RTS)
 
-#define COMMS_TIMEOUT			100		// Timeout for VDP commands (ms)
+#define COMMS_TIMEOUT			200		// Timeout for VDP commands (ms)
 
 #define UART_RX_SIZE			256		// The RX buffer size
 #define UART_RX_THRESH			128		// Point at which RTS is toggled

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -152,7 +152,12 @@ uint8_t VDUStreamProcessor::loadSample(uint8_t sampleIndex, uint32_t length) {
 
 		if (data) {
 			// read data into buffer
-			for (auto n = 0; n < length; n++) sample->data[n] = readByte_b();
+			auto remaining = readIntoBuffer((uint8_t *)data, length);
+			if (remaining != 0) {
+				// Failed to read all data
+				debug_log("vdu_sys_audio: sample %d - data discarded, failed to read all data\n\r", sampleIndex);
+				return 0;
+			}
 			samples[sampleIndex] = sample;
 			debug_log("vdu_sys_audio: sample %d - data loaded, length %d\n\r", sampleIndex, sample->length);
 			return 1;

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -67,9 +67,11 @@ void VDUStreamProcessor::bufferWrite(uint16_t bufferId) {
 
 	debug_log("bufferWrite: storing stream into buffer %d, length %d\n\r", bufferId, length);
 
-	for (auto i = 0; i < length; i++) {
-		auto data = readByte_b();
-		bufferStream->writeBufferByte(data, i);
+	auto remaining = readIntoBuffer(bufferStream->getBuffer(), length);
+	if (remaining > 0) {
+		// NB this discards the data we just read
+		debug_log("bufferWrite: timed out write for buffer %d (%d bytes remaining)\n\r", bufferId, remaining);
+		return;
 	}
 
 	buffers[bufferId].push_back(std::move(bufferStream));

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -163,9 +163,13 @@ void VDUStreamProcessor::vdu_sys_video() {
 // VDU 23, 0, &80, <echo>: Send a general poll/echo byte back to MOS
 //
 void VDUStreamProcessor::sendGeneralPoll() {
-	auto b = readByte_b();
+	auto b = readByte_t();
+	if (b == -1) {
+		debug_log("sendGeneralPoll: Timeout\n\r");
+		return;
+	}
 	uint8_t packet[] = {
-		b,
+		(uint8_t) (b & 0xFF),
 	};
 	send_packet(PACKET_GP, sizeof packet, packet);
 	initialised = true;	


### PR DESCRIPTION
Updates _almost_ all comms code between the z80 and VDP to be non-blocking, and to timeout.
(The only blocking read commands that remain are those inside `hexload.h`)

Adds a `readIntoBuffer` call, which is used for all places that read data from the VDU stream into a buffer.  This call is given a buffer pointer and the number of bytes we're expecting to read, and will return zero when the buffer has been read successfully, or if the read times out the number of bytes that were missing.  The timeout is based on the time from when data was last received, rather than when the call was made.  This way larger transfers shouldn't timeout unless there is a genuine delay.

The performance of `readIntoBuffer` in testing is identical to @astralaster's earlier comms performance enhancement code.  (It uses a very similar technique.)

`discardBytes` has also been updated to be non-blocking.

A great plus with these changes is that the VDP will no longer hang waiting for data that will never come on dodgy/flakey VDU calls.  For example, attempting to use an "upload bitmap" or "upload sample" call from the CLI often/usually results in a command that doesn't include all the expected data.  (Sending a byte instead of a word for one of those calls typically results in the VDP expecting _far_ more data than the user intended.)  When this happens the VDP would be left in a state waiting for data that could never come, requiring the user to press the "reset" button to recover.

With these changes the command times out, the data will be discarded, and the computer is usable again.

(NB typically when such faulty commands are sent, the VDU system will also be sent other data such as the `>` prompt in BASIC, which will be captured as part of the data stream.  If the user has sent a duff command from the BASIC CLI they'll be left on an empty line with no visible prompt, but they can enter commands.)