### PR TITLE
Buffered command enhancements, including buffered bitmaps and samples

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -150,7 +150,7 @@
 
 // Adjust operation flags
 #define ADJUST_OP_MASK			0x0F	// operation code mask
-#define ADJUST_24BIT_OFFSETS	0x10	// offset values are 24-bit
+#define ADJUST_ADVANCED_OFFSETS	0x10	// advanced, 24-bit offsets (16-bit block offset follows if top bit set)
 #define ADJUST_BUFFER_VALUE		0x20	// operand is a buffer fetched value
 #define ADJUST_MULTI_TARGET		0x40	// multiple target values will be adjusted
 #define ADJUST_MULTI_OPERAND	0x80	// multiple operand values used for adjustments
@@ -169,7 +169,7 @@
 
 // Conditional operation flags
 #define COND_OP_MASK			0x0F	// conditional operation code mask
-#define COND_24BIT_OFFSETS		0x10	// offset values are 24-bit
+#define COND_ADVANCED_OFFSETS	0x10	// advanced offset values
 #define COND_BUFFER_VALUE		0x20	// value to compare is a buffer-fetched value
 
 // Buffered bitmap info

--- a/video/agon.h
+++ b/video/agon.h
@@ -134,8 +134,9 @@
 #define BUFFERED_CONSOLIDATE	0x0C	// Consolidate blocks inside a buffer into one
 #define BUFFERED_SPLIT			0x0D	// Split a buffer into multiple blocks
 #define BUFFERED_REVERSE_BLOCKS	0x0E	// Reverse the order of blocks in a buffer
+#define BUFFERED_REVERSE		0x0F	// Reverse the order of data in a buffer
 
-#define BUFFERED_DEBUG_INFO		0x10	// Get debug info about a buffer
+#define BUFFERED_DEBUG_INFO		0x20	// Get debug info about a buffer
 
 // Adjust operation codes
 #define ADJUST_NOT				0x00	// Adjust: NOT

--- a/video/agon.h
+++ b/video/agon.h
@@ -169,6 +169,9 @@
 #define COND_24BIT_OFFSETS		0x10	// offset values are 24-bit
 #define COND_BUFFER_VALUE		0x20	// value to compare is a buffer-fetched value
 
+// Buffered bitmap info
+#define BUFFERED_BITMAP_BASEID	0xFA00	// Base ID for buffered bitmaps
+
 // Viewport definitions
 #define VIEWPORT_TEXT			0		// Text viewport
 #define VIEWPORT_DEFAULT		1		// Default (whole screen) viewport

--- a/video/agon.h
+++ b/video/agon.h
@@ -130,8 +130,10 @@
 #define BUFFERED_COND_JUMP		0x08	// Conditionally jump to a buffer
 #define BUFFERED_OFFSET_JUMP	0x09	// Jump to a buffer with an offset
 #define BUFFERED_OFFSET_COND_JUMP	0x0A	// Conditionally jump to a buffer with an offset
-#define BUFFERED_COPY			0x0B	// Copy buffers (raw)
-#define BUFFERED_CONSOLIDATE	0x0C	// Consolidate buffers into one
+#define BUFFERED_COPY			0x0B	// Copy blocks from multiple buffers into one buffer
+#define BUFFERED_CONSOLIDATE	0x0C	// Consolidate blocks inside a buffer into one
+#define BUFFERED_SPLIT			0x0D	// Split a buffer into multiple blocks
+#define BUFFERED_REVERSE_BLOCKS	0x0E	// Reverse the order of blocks in a buffer
 
 #define BUFFERED_DEBUG_INFO		0x10	// Get debug info about a buffer
 

--- a/video/agon.h
+++ b/video/agon.h
@@ -65,7 +65,6 @@
 
 #define AUDIO_CHANNELS			3		// Default number of audio channels
 #define MAX_AUDIO_CHANNELS		32		// Maximum number of audio channels
-#define MAX_AUDIO_SAMPLES		128		// Maximum number of audio samples
 #define PLAY_SOUND_PRIORITY		3		// Sound driver task priority with 3 (configMAX_PRIORITIES - 1) being the highest, and 0 being the lowest
 
 // Audio command definitions
@@ -89,12 +88,16 @@
 #define AUDIO_WAVE_SINE			3		// Sine wave
 #define AUDIO_WAVE_NOISE		4		// Noise (simple, no frequency support)
 #define AUDIO_WAVE_VICNOISE		5		// VIC-style noise (supports frequency)
-#define AUDIO_WAVE_SAMPLE		8		// Sample playback (internally used, can't be passed as a parameter)
+#define AUDIO_WAVE_SAMPLE		8		// Sample playback, explicit buffer ID sent in following 2 bytes
 // negative values for waveforms indicate a sample number
 
 #define AUDIO_SAMPLE_LOAD		0		// Send a sample to the VDP
 #define AUDIO_SAMPLE_CLEAR		1		// Clear/delete a sample
-#define AUDIO_SAMPLE_DEBUG_INFO 2		// Get debug info about a sample
+#define AUDIO_SAMPLE_FROM_BUFFER	2	// Load a sample from a buffer
+#define AUDIO_SAMPLE_DEBUG_INFO 0x10	// Get debug info about a sample
+
+#define AUDIO_FORMAT_8BIT_SIGNED	0	// 8-bit signed sample
+#define AUDIO_FORMAT_8BIT_UNSIGNED	1	// 8-bit unsigned sample
 
 #define AUDIO_ENVELOPE_NONE		0		// No envelope
 #define AUDIO_ENVELOPE_ADSR		1		// Simple ADSR volume envelope
@@ -189,8 +192,9 @@
 #define REVERSE_BLOCK			0x08	// reverse block order
 #define REVERSE_UNUSED_BITS		0xF0	// unused bits
 
-// Buffered bitmap info
+// Buffered bitmap and sample info
 #define BUFFERED_BITMAP_BASEID	0xFA00	// Base ID for buffered bitmaps
+#define BUFFERED_SAMPLE_BASEID	0xFB00	// Base ID for buffered samples
 
 // Viewport definitions
 #define VIEWPORT_TEXT			0		// Text viewport

--- a/video/agon.h
+++ b/video/agon.h
@@ -125,7 +125,14 @@
 #define BUFFERED_CREATE			0x03	// Create a new empty buffer
 #define BUFFERED_SET_OUTPUT		0x04	// Set the output buffer
 #define BUFFERED_ADJUST			0x05	// Adjust buffered commands
-#define BUFFERED_CONDITIONAL	0x06	// Conditionally call a buffer
+#define BUFFERED_COND_CALL		0x06	// Conditionally call a buffer
+#define BUFFERED_JUMP			0x07	// Jump to a buffer
+#define BUFFERED_COND_JUMP		0x08	// Conditionally jump to a buffer
+#define BUFFERED_OFFSET_JUMP	0x09	// Jump to a buffer with an offset
+#define BUFFERED_OFFSET_COND_JUMP	0x0A	// Conditionally jump to a buffer with an offset
+#define BUFFERED_COPY			0x0B	// Copy buffers (raw)
+#define BUFFERED_CONSOLIDATE	0x0C	// Consolidate buffers into one
+
 #define BUFFERED_DEBUG_INFO		0x10	// Get debug info about a buffer
 
 // Adjust operation codes

--- a/video/agon.h
+++ b/video/agon.h
@@ -130,11 +130,13 @@
 #define BUFFERED_COND_JUMP		0x08	// Conditionally jump to a buffer
 #define BUFFERED_OFFSET_JUMP	0x09	// Jump to a buffer with an offset
 #define BUFFERED_OFFSET_COND_JUMP	0x0A	// Conditionally jump to a buffer with an offset
-#define BUFFERED_COPY			0x0B	// Copy blocks from multiple buffers into one buffer
-#define BUFFERED_CONSOLIDATE	0x0C	// Consolidate blocks inside a buffer into one
-#define BUFFERED_SPLIT			0x0D	// Split a buffer into multiple blocks
-#define BUFFERED_REVERSE_BLOCKS	0x0E	// Reverse the order of blocks in a buffer
-#define BUFFERED_REVERSE		0x0F	// Reverse the order of data in a buffer
+#define BUFFERED_OFFSET_CALL    0x0B	// Call a buffer with an offset
+#define BUFFERED_OFFSET_COND_CALL	0x0C	// Conditionally call a buffer with an offset
+#define BUFFERED_COPY			0x0D	// Copy blocks from multiple buffers into one buffer
+#define BUFFERED_CONSOLIDATE	0x0E	// Consolidate blocks inside a buffer into one
+#define BUFFERED_SPLIT			0x0F	// Split a buffer into multiple blocks
+#define BUFFERED_REVERSE_BLOCKS	0x10	// Reverse the order of blocks in a buffer
+#define BUFFERED_REVERSE		0x11	// Reverse the order of data in a buffer
 
 #define BUFFERED_DEBUG_INFO		0x20	// Get debug info about a buffer
 

--- a/video/agon.h
+++ b/video/agon.h
@@ -26,7 +26,7 @@
 #define UART_RTS				13		// The ESP32 RTS pin (eZ80 CTS)
 #define UART_CTS	 			14		// The ESP32 CTS pin (eZ80 RTS)
 
-#define COMMS_TIMEOUT			100		// Timeout for VDP commands (ms)
+#define COMMS_TIMEOUT			200		// Timeout for VDP commands (ms)
 
 #define UART_RX_SIZE			256		// The RX buffer size
 #define UART_RX_THRESH			128		// Point at which RTS is toggled

--- a/video/agon.h
+++ b/video/agon.h
@@ -135,8 +135,15 @@
 #define BUFFERED_COPY			0x0D	// Copy blocks from multiple buffers into one buffer
 #define BUFFERED_CONSOLIDATE	0x0E	// Consolidate blocks inside a buffer into one
 #define BUFFERED_SPLIT			0x0F	// Split a buffer into multiple blocks
-#define BUFFERED_REVERSE_BLOCKS	0x10	// Reverse the order of blocks in a buffer
-#define BUFFERED_REVERSE		0x11	// Reverse the order of data in a buffer
+#define BUFFERED_SPLIT_INTO		0x10	// Split a buffer into multiple blocks to new buffer(s)
+#define BUFFERED_SPLIT_FROM		0x11	// Split to new buffers from a target bufferId onwards
+#define BUFFERED_SPLIT_BY		0x12	// Split a buffer into multiple blocks by width (columns)
+#define BUFFERED_SPLIT_BY_INTO	0x13	// Split by width into new buffer(s)
+#define BUFFERED_SPLIT_BY_FROM	0x14	// Split by width to new buffers from a target bufferId onwards
+#define BUFFERED_SPREAD_INTO	0x15	// Spread blocks from a buffer to multiple target buffers
+#define BUFFERED_SPREAD_FROM	0x16	// Spread blocks from target buffer ID onwards
+#define BUFFERED_REVERSE_BLOCKS	0x17	// Reverse the order of blocks in a buffer
+#define BUFFERED_REVERSE		0x18	// Reverse the order of data in a buffer
 
 #define BUFFERED_DEBUG_INFO		0x20	// Get debug info about a buffer
 

--- a/video/agon.h
+++ b/video/agon.h
@@ -130,7 +130,7 @@
 #define BUFFERED_COND_JUMP		0x08	// Conditionally jump to a buffer
 #define BUFFERED_OFFSET_JUMP	0x09	// Jump to a buffer with an offset
 #define BUFFERED_OFFSET_COND_JUMP	0x0A	// Conditionally jump to a buffer with an offset
-#define BUFFERED_OFFSET_CALL    0x0B	// Call a buffer with an offset
+#define BUFFERED_OFFSET_CALL	0x0B	// Call a buffer with an offset
 #define BUFFERED_OFFSET_COND_CALL	0x0C	// Conditionally call a buffer with an offset
 #define BUFFERED_COPY			0x0D	// Copy blocks from multiple buffers into one buffer
 #define BUFFERED_CONSOLIDATE	0x0E	// Consolidate blocks inside a buffer into one
@@ -173,6 +173,14 @@
 #define COND_OP_MASK			0x0F	// conditional operation code mask
 #define COND_ADVANCED_OFFSETS	0x10	// advanced offset values
 #define COND_BUFFER_VALUE		0x20	// value to compare is a buffer-fetched value
+
+// Reverse operation flags
+#define REVERSE_16BIT			0x01	// 16-bit value length
+#define REVERSE_32BIT			0x02	// 32-bit value length
+#define REVERSE_SIZE			0x03	// when both length flags are set, a 16-bit length value follows
+#define REVERSE_CHUNKED			0x04	// chunked reverse, 16-bit size value follows
+#define REVERSE_BLOCK			0x08	// reverse block order
+#define REVERSE_UNUSED_BITS		0xF0	// unused bits
 
 // Buffered bitmap info
 #define BUFFERED_BITMAP_BASEID	0xFA00	// Base ID for buffered bitmaps

--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -139,4 +139,11 @@ uint8_t clearSample(uint16_t sampleId) {
 	return 1;
 }
 
+// Reset samples
+//
+void resetSamples() {
+	debug_log("resetSamples\n\r");
+	samples.clear();
+}
+
 #endif // AGON_AUDIO_H

--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -23,7 +23,7 @@
 std::unordered_map<uint8_t, std::shared_ptr<audio_channel>> audio_channels;
 std::vector<TaskHandle_t, psram_allocator<TaskHandle_t>> audioHandlers;
 
-std::unordered_map<uint8_t, std::shared_ptr<audio_sample>> samples;	// Storage for the sample data
+std::unordered_map<uint16_t, std::shared_ptr<audio_sample>> samples;	// Storage for the sample data
 
 fabgl::SoundGenerator		SoundGenerator;		// The audio class
 
@@ -119,27 +119,24 @@ void setFrequency(uint8_t channel, uint16_t frequency) {
 
 // Set channel waveform
 //
-void setWaveform(uint8_t channel, int8_t waveformType) {
+void setWaveform(uint8_t channel, int8_t waveformType, uint16_t sampleId) {
 	if (channelEnabled(channel)) {
 		auto channelRef = audio_channels[channel];
-		channelRef->setWaveform(waveformType, channelRef);
+		channelRef->setWaveform(waveformType, channelRef, sampleId);
 	}
 }
 
 // Clear a sample
 //
-uint8_t clearSample(uint8_t sampleIndex) {
-	debug_log("clearSample: sample %d\n\r", sampleIndex);
-	if (sampleIndex < MAX_AUDIO_SAMPLES) {
-		if (samples.find(sampleIndex) == samples.end()) {
-			debug_log("clearSample: sample %d not found\n\r", sampleIndex);
-			return 0;
-		}
-		samples.erase(sampleIndex);
-		debug_log("reset sample\n\r");
-		return 1;
+uint8_t clearSample(uint16_t sampleId) {
+	debug_log("clearSample: sample %d\n\r", sampleId);
+	if (samples.find(sampleId) == samples.end()) {
+		debug_log("clearSample: sample %d not found\n\r", sampleId);
+		return 0;
 	}
-	return 0;
+	samples.erase(sampleId);
+	debug_log("reset sample\n\r");
+	return 1;
 }
 
 #endif // AGON_AUDIO_H

--- a/video/audio_sample.h
+++ b/video/audio_sample.h
@@ -6,17 +6,13 @@
 
 #include "types.h"
 #include "audio_channel.h"
+#include "buffer_stream.h"
 
 struct audio_sample {
-	audio_sample(uint32_t length) : length(length) {
-		data = (int8_t *) PreferPSRAMAlloc(length);
-		if (!data) {
-			debug_log("audio_sample: failed to allocate %d bytes\n\r", length);
-		}
-	}
+	audio_sample(std::vector<std::shared_ptr<BufferStream>> streams, uint8_t format) : blocks(streams), format(format) {}
 	~audio_sample();
-	uint32_t		length = 0;			// Length of the sample in bytes
-	int8_t *		data = nullptr;		// Pointer to the sample data
+	std::vector<std::shared_ptr<BufferStream>> blocks;
+	uint8_t			format = 0;			// Format of the sample data
 	std::unordered_map<uint8_t, std::weak_ptr<audio_channel>> channels;	// Channels playing this sample
 };
 
@@ -31,11 +27,6 @@ audio_sample::~audio_sample() {
 			channel->setWaveform(AUDIO_WAVE_DEFAULT, nullptr);
 		}
 	}
-
-	if (this->data) {
-		free(this->data);
-	}
-
 	debug_log("audio_sample cleared\n\r");
 }
 

--- a/video/audio_sample.h
+++ b/video/audio_sample.h
@@ -9,10 +9,26 @@
 #include "buffer_stream.h"
 
 struct audio_sample {
-	audio_sample(std::vector<std::shared_ptr<BufferStream>> streams, uint8_t format) : blocks(streams), format(format) {}
+	audio_sample(std::vector<std::shared_ptr<BufferStream>>& streams, uint8_t format) : blocks(streams), format(format), index(0), blockIndex(0) {}
 	~audio_sample();
-	std::vector<std::shared_ptr<BufferStream>> blocks;
-	uint8_t			format = 0;			// Format of the sample data
+	int8_t getSample();
+	void rewind() {
+		index = 0;
+		blockIndex = 0;
+	}
+	void checkIndexes() {
+		if (blockIndex >= blocks.size()) {
+			blockIndex = 0;
+			index = 0;
+		}
+		if (index >= blocks[blockIndex]->size()) {
+			index = 0;
+		}
+	}
+	std::vector<std::shared_ptr<BufferStream>>& blocks;
+	uint8_t			format;			// Format of the sample data
+	uint32_t		index;			// Current index inside the current sample block
+	uint32_t		blockIndex;		// Current index into the sample data blocks
 	std::unordered_map<uint8_t, std::weak_ptr<audio_channel>> channels;	// Channels playing this sample
 };
 
@@ -28,6 +44,27 @@ audio_sample::~audio_sample() {
 		}
 	}
 	debug_log("audio_sample cleared\n\r");
+}
+
+int8_t audio_sample::getSample() {
+	// our blocks might have changed, so we need to check if we're still in range
+	checkIndexes();
+
+	auto block = blocks[blockIndex];
+	int8_t sample = block->getBuffer()[index++];
+	
+	// Insert looping magic here
+	if (index >= block->size()) {
+		// block reached end, move to next, or loop
+		index = 0;
+		blockIndex++;
+	}
+
+	if (format == AUDIO_FORMAT_8BIT_UNSIGNED) {
+		sample = sample - 128;
+	}
+
+	return sample;
 }
 
 #endif // AUDIO_SAMPLE_H

--- a/video/buffer_stream.h
+++ b/video/buffer_stream.h
@@ -18,7 +18,11 @@ class BufferStream : public Stream {
 		}
 
 		void rewind() {
-			bufferPosition = 0;
+			seekTo(0);
+		}
+
+		void seekTo(uint32_t position) {
+			bufferPosition = position;
 		}
 
 		inline uint8_t * getBuffer() {

--- a/video/buffers.h
+++ b/video/buffers.h
@@ -9,4 +9,114 @@
 
 std::unordered_map<uint16_t, std::vector<std::shared_ptr<BufferStream>>> buffers;
 
+// Utility functions for buffer management:
+
+// Resolve a buffer id
+int32_t resolveBufferId(int32_t bufferId, uint16_t currentId) {
+	if (bufferId == 65535) {
+		// buffer ID of 65535 means use the current buffer
+		if (currentId == 65535) {
+			// this is an error, we can't resolve a buffer id if we're not in a buffer call
+			return -1;
+		}
+		return currentId;
+	}
+	return bufferId;
+}
+
+// Reverse values in a buffer
+void reverseValues(uint8_t * data, uint32_t length, uint8_t valueSize) {
+	// get last offset into buffer
+	auto bufferEnd = length - valueSize;
+
+	if (valueSize == 1) {
+		// reverse the data
+		for (auto i = 0; i <= (bufferEnd / 2); i++) {
+			auto temp = data[i];
+			data[i] = data[bufferEnd - i];
+			data[bufferEnd - i] = temp;
+		}
+	} else {
+		// reverse the data in chunks
+		for (auto i = 0; i <= (bufferEnd / (valueSize * 2)); i++) {
+			auto sourceOffset = i * valueSize;
+			auto targetOffset = bufferEnd - sourceOffset;
+			for (auto j = 0; j < valueSize; j++) {
+				auto temp = data[sourceOffset + j];
+				data[sourceOffset + j] = data[targetOffset + j];
+				data[targetOffset + j] = temp;
+			}
+		}
+	}
+}
+
+// Work out which buffer to use next
+void updateTarget(std::vector<uint16_t> targets, uint16_t &target, uint16_t &index, bool iterate) {
+	if (iterate) {
+		// if the iterate flag is set, we just use the next buffer
+		if (target < 65535) {
+			target++;
+		}
+	} else {
+		// use the next buffer in the list, or loop back to the start
+		index++;
+		if (index >= targets.size()) {
+			index = 0;
+		}
+		target = targets[index];
+	}
+}
+
+// consolidate blocks/streams into a single buffer
+std::shared_ptr<BufferStream> consolidateBuffers(std::vector<std::shared_ptr<BufferStream>>& streams) {
+	// don't do anything if only one stream
+	if (streams.size() == 1) {
+		return streams[0];
+	}
+	// work out total length of buffer
+	uint32_t length = 0;
+	for (auto block : streams) {
+		length += block->size();
+	}
+	auto bufferStream = make_shared_psram<BufferStream>(length);
+	if (!bufferStream || !bufferStream->getBuffer()) {
+		// buffer couldn't be created
+		return nullptr;
+	}
+	auto offset = 0;
+	for (auto block : streams) {
+		auto bufferLength = block->size();
+		memcpy(bufferStream->getBuffer() + offset, block->getBuffer(), bufferLength);
+		offset += bufferLength;
+	}
+	return bufferStream;
+}
+
+// split a buffer into multiple blocks/chunks
+std::vector<std::shared_ptr<BufferStream>> splitBuffer(std::shared_ptr<BufferStream> buffer, uint16_t length) {
+	std::vector<std::shared_ptr<BufferStream>> chunks;
+	auto totalLength = buffer->size();
+	auto remaining = totalLength;
+	auto sourceData = buffer->getBuffer();
+
+	// chop up source data by length, storing into new buffers
+	// looping the buffer list until we have no data left
+	while (remaining > 0) {
+		auto bufferLength = length;
+		if (remaining < bufferLength) {
+			bufferLength = remaining;
+		}
+		auto chunk = make_shared_psram<BufferStream>(bufferLength);
+		if (!chunk || !chunk->getBuffer()) {
+			// buffer couldn't be created, so return an empty vector
+			return {};
+		}
+		memcpy(chunk->getBuffer(), sourceData, bufferLength);
+		chunks.push_back(chunk);
+		sourceData += bufferLength;
+		remaining -= bufferLength;
+	}
+	return chunks;
+}
+
 #endif // BUFFERS_H

--- a/video/buffers.h
+++ b/video/buffers.h
@@ -1,0 +1,12 @@
+#ifndef BUFFERS_H
+#define BUFFERS_H
+
+#include <memory>
+#include <vector>
+#include <unordered_map>
+
+#include "buffer_stream.h"
+
+std::unordered_map<uint16_t, std::vector<std::shared_ptr<BufferStream>>> buffers;
+
+#endif // BUFFERS_H

--- a/video/hexload.h
+++ b/video/hexload.h
@@ -48,7 +48,7 @@ void VDUStreamProcessor::vdu_sys_hexload(void) {
 	uint8_t data;
 	uint8_t ihexchecksum,ez80checksum;
 
-	bool done,defaultaddress,ez80checksumerror;
+	bool done,defaultaddress;
 	uint16_t errorcount;
 
 	printFmt("Receiving Intel HEX records - VDP:%d 8N1\r\n\r\n", SERIALBAUDRATE);

--- a/video/multi_buffer_stream.h
+++ b/video/multi_buffer_stream.h
@@ -10,7 +10,7 @@
 
 class MultiBufferStream : public Stream {
 	public:
-		MultiBufferStream(std::vector<std::shared_ptr<BufferStream>, psram_allocator<std::shared_ptr<BufferStream>>> buffers);
+		MultiBufferStream(std::vector<std::shared_ptr<BufferStream>> buffers);
 		int available();
 		int read();
 		int peek();
@@ -19,12 +19,12 @@ class MultiBufferStream : public Stream {
 		void seekTo(uint32_t position);
 		uint32_t size();
 	private:
-		std::vector<std::shared_ptr<BufferStream>, psram_allocator<std::shared_ptr<BufferStream>>> buffers;
+		std::vector<std::shared_ptr<BufferStream>> buffers;
 		std::shared_ptr<BufferStream> getBuffer();
 		size_t currentBufferIndex = 0;
 };
 
-MultiBufferStream::MultiBufferStream(std::vector<std::shared_ptr<BufferStream>, psram_allocator<std::shared_ptr<BufferStream>>> buffers) : buffers(buffers) {
+MultiBufferStream::MultiBufferStream(std::vector<std::shared_ptr<BufferStream>> buffers) : buffers(buffers) {
 	// rewind all buffers, in case they've been used before
 	rewind();
 }

--- a/video/sprites.h
+++ b/video/sprites.h
@@ -1,6 +1,9 @@
 #ifndef SPRITES_H
 #define SPRITES_H
 
+#include <memory>
+#include <vector>
+#include <unordered_map>
 #include <fabgl.h>
 
 #include "agon.h"
@@ -9,15 +12,30 @@
 uint8_t			numsprites = 0;					// Number of sprites on stage
 uint8_t			current_sprite = 0;				// Current sprite number
 uint8_t			current_bitmap = 0;				// Current bitmap number
+uint16_t		currentBitmap = 0;				// Current bitmap ID
 Bitmap			bitmaps[MAX_BITMAPS];			// Bitmap object storage
 Sprite			sprites[MAX_SPRITES];			// Sprite object storage
+
+std::unordered_map<uint16_t, std::shared_ptr<Bitmap>> zbitmaps;
 
 Bitmap * getBitmap(uint8_t b = current_bitmap) {
 	return &bitmaps[b];
 }
 
+std::shared_ptr<Bitmap> getBitmap(uint16_t id) {
+	if (zbitmaps.find(id) != zbitmaps.end()) {
+		return zbitmaps[id];
+	}
+	return nullptr;
+}
+
 inline void setCurrentBitmap(uint8_t b) {
 	current_bitmap = b;
+	currentBitmap = b + BUFFERED_BITMAP_BASEID;
+}
+
+inline void setCurrentBitmap(uint16_t b) {
+	currentBitmap = b;
 }
 
 inline uint8_t getCurrentBitmap() {
@@ -40,10 +58,20 @@ void createBitmap(uint16_t width, uint16_t height, void * data, PixelFormat form
 }
 
 void drawBitmap(uint16_t x, uint16_t y) {
-	auto bitmap = getBitmap();
+	auto bitmap = getBitmap(current_bitmap);
 	if (bitmap->data) {
 		canvas->drawBitmap(x, y, bitmap);
 		waitPlotCompletion();
+	}
+}
+
+void drawBitmapZ(uint16_t x, uint16_t y) {
+	auto bitmap = getBitmap(currentBitmap);
+	if (bitmap) {
+		canvas->drawBitmap(x, y, bitmap.get());
+		waitPlotCompletion();
+	} else {
+		debug_log("drawBitmapZ: bitmap %d not found\n\r", currentBitmap);
 	}
 }
 

--- a/video/sprites.h
+++ b/video/sprites.h
@@ -9,7 +9,7 @@
 #include "agon.h"
 #include "agon_screen.h"
 
-uint16_t		currentBitmap = 0;				// Current bitmap ID
+uint16_t		currentBitmap = BUFFERED_BITMAP_BASEID;	// Current bitmap ID
 std::unordered_map<uint16_t, std::shared_ptr<Bitmap>> bitmaps;	// Storage for our bitmaps
 uint8_t			numsprites = 0;					// Number of sprites on stage
 uint8_t			current_sprite = 0;				// Current sprite number
@@ -47,6 +47,7 @@ void resetBitmaps() {
 	bitmaps.clear();
 	// this will only be used after resetting sprites, so we can clear the bitmapUsers list
 	bitmapUsers.clear();
+	setCurrentBitmap(BUFFERED_BITMAP_BASEID);
 }
 
 Sprite * getSprite(uint8_t sprite = current_sprite) {
@@ -184,6 +185,7 @@ void resetSprites() {
 		clearSpriteFrames(n);
 	}
 	activateSprites(0);
+	setCurrentSprite(0);
 	// replace all the sprite objects
 	// for (auto n = 0; n < MAX_SPRITES; n++) {
 	// 	sprites[n] = Sprite();

--- a/video/sprites.h
+++ b/video/sprites.h
@@ -68,7 +68,6 @@ void clearSpriteFrames(uint8_t s = current_sprite) {
 	sprite->clearBitmaps();
 	// find all bitmaps used by this sprite and remove it from the list
 	for (auto bitmapUser : bitmapUsers) {
-		auto bitmapId = bitmapUser.first;
 		auto users = bitmapUser.second;
 		// remove all instances of this sprite from the users list
 		auto it = std::find(users.begin(), users.end(), s);

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -152,7 +152,12 @@ uint8_t VDUStreamProcessor::loadSample(uint8_t sampleIndex, uint32_t length) {
 
 		if (data) {
 			// read data into buffer
-			for (auto n = 0; n < length; n++) sample->data[n] = readByte_b();
+			auto remaining = readIntoBuffer((uint8_t *)data, length);
+			if (remaining != 0) {
+				// Failed to read all data
+				debug_log("vdu_sys_audio: sample %d - data discarded, failed to read all data\n\r", sampleIndex);
+				return 0;
+			}
 			samples[sampleIndex] = sample;
 			debug_log("vdu_sys_audio: sample %d - data loaded, length %d\n\r", sampleIndex, sample->length);
 			return 1;

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -15,6 +15,7 @@
 #include "agon.h"
 #include "agon_audio.h"
 #include "types.h"
+#include "vdu_buffered.h"
 
 // Audio VDU command support (VDU 23, 0, &85, <args>)
 //
@@ -49,16 +50,23 @@ void VDUStreamProcessor::vdu_sys_audio() {
 
 		case AUDIO_CMD_WAVEFORM: {
 			auto waveform = readByte_t();	if (waveform == -1) return;
+			auto sampleNum = 0;
+
+			if (waveform == AUDIO_WAVE_SAMPLE) {
+				// explit buffer number given for sample
+				sampleNum = readWord_t();	if (sampleNum == -1) return;
+			}
 
 			// set waveform, interpretting waveform number as a signed 8-bit value
 			// to allow for negative values to be used as sample numbers
-			setWaveform(channel, (int8_t) waveform);
+			setWaveform(channel, (int8_t) waveform, sampleNum);
 		}	break;
 
 		case AUDIO_CMD_SAMPLE: {
-			// sample number is negative 8 bit number, and provided in channel number param
-			int8_t sampleNum = -(int8_t)channel - 1;	// convert to positive, ranged from zero
 			auto action = readByte_t();		if (action == -1) return;
+
+			// sample number is negative 8 bit number, and provided in channel number param
+			int16_t sampleNum = BUFFERED_SAMPLE_BASEID + (-(int8_t)channel - 1);	// convert to positive, ranged from zero
 
 			switch (action) {
 				case AUDIO_SAMPLE_LOAD: {
@@ -73,18 +81,25 @@ void VDUStreamProcessor::vdu_sys_audio() {
 					sendAudioStatus(channel, clearSample(sampleNum));
 				}	break;
 
+				case AUDIO_SAMPLE_FROM_BUFFER: {
+					auto bufferId = readWord_t();	if (bufferId == -1) return;
+					auto format = readByte_t();		if (format == -1) return;
+
+					sendAudioStatus(channel, createSampleFromBuffer(bufferId, format));
+				}	break;
+
 				case AUDIO_SAMPLE_DEBUG_INFO: {
 					debug_log("Sample info: %d (%d)\n\r", (int8_t)channel, sampleNum);
 					debug_log("  samples count: %d\n\r", samples.size());
 					debug_log("  free mem: %d\n\r", heap_caps_get_free_size(MALLOC_CAP_8BIT));
-					audio_sample* sample = samples[sampleNum].get();
+					auto sample = samples[sampleNum];
 					if (sample == nullptr) {
 						debug_log("  sample is null\n\r");
 						break;
 					}
-					debug_log("  length: %d\n\r", sample->length);
-					if (sample->length > 0) {
-						debug_log("  data first byte: %d\n\r", sample->data[0]);
+					debug_log("  length: %d\n\r", sample->blocks.size());
+					if (sample->blocks.size() > 0) {
+						debug_log("  data first byte: %d\n\r", sample->blocks[0]->getBuffer()[0]);
 					}
 				} break;
 
@@ -140,38 +155,32 @@ void VDUStreamProcessor::sendAudioStatus(uint8_t channel, uint8_t status) {
 
 // Load a sample
 //
-uint8_t VDUStreamProcessor::loadSample(uint8_t sampleIndex, uint32_t length) {
+uint8_t VDUStreamProcessor::loadSample(uint16_t bufferId, uint32_t length) {
 	debug_log("free mem: %d\n\r", heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
-	if (sampleIndex < MAX_AUDIO_SAMPLES) {
-		debug_log("loadSample: sample %d - length %d\n\r", sampleIndex, length);
-		// Clear out existing sample
-		clearSample(sampleIndex);
 
-		auto sample = make_shared_psram<audio_sample>(length);
-		auto data = sample->data;
+	bufferClear(bufferId);
 
-		if (data) {
-			// read data into buffer
-			auto remaining = readIntoBuffer((uint8_t *)data, length);
-			if (remaining != 0) {
-				// Failed to read all data
-				debug_log("vdu_sys_audio: sample %d - data discarded, failed to read all data\n\r", sampleIndex);
-				return 0;
-			}
-			samples[sampleIndex] = sample;
-			debug_log("vdu_sys_audio: sample %d - data loaded, length %d\n\r", sampleIndex, sample->length);
-			return 1;
-		} else {
-			// Failed to allocate memory
-			// discard incoming serial data
-			discardBytes(length);
-			debug_log("vdu_sys_audio: sample %d - data discarded, no memory available length %d\n\r", sampleIndex, length);
-			return 0;
-		}
+	if (bufferWrite(bufferId, length) != 0) {
+		// timed out, or couldn't allocate buffer - so abort
+		return 0;
 	}
-	// Invalid sample number - discard incoming serial data
-	discardBytes(length);
-	debug_log("vdu_sys_audio: sample %d - data discarded, invalid sample number\n\r", sampleIndex);
+	return createSampleFromBuffer(bufferId, 0);
+}
+
+// Create a sample from a buffer
+//
+uint8_t VDUStreamProcessor::createSampleFromBuffer(uint16_t bufferId, uint8_t format) {
+	if (buffers.find(bufferId) == buffers.end()) {
+		debug_log("vdu_sys_audio: buffer %d not found\n\r", bufferId);
+		return 0;
+	}
+	clearSample(bufferId);
+	// create sample from buffer
+	auto sample = make_shared_psram<audio_sample>(buffers[bufferId], format);
+	if (sample) {
+		samples[bufferId] = sample;
+		return 1;
+	}
 	return 0;
 }
 

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -14,8 +14,8 @@
 
 #include "agon.h"
 #include "agon_audio.h"
+#include "buffers.h"
 #include "types.h"
-#include "vdu_buffered.h"
 
 // Audio VDU command support (VDU 23, 0, &85, <args>)
 //
@@ -97,9 +97,10 @@ void VDUStreamProcessor::vdu_sys_audio() {
 						debug_log("  sample is null\n\r");
 						break;
 					}
-					debug_log("  length: %d\n\r", sample->blocks.size());
-					if (sample->blocks.size() > 0) {
-						debug_log("  data first byte: %d\n\r", sample->blocks[0]->getBuffer()[0]);
+					auto buffer = sample->blocks;
+					debug_log("  length: %d\n\r", buffer.size());
+					if (buffer.size() > 0) {
+						debug_log("  data first byte: %d\n\r", buffer[0]->getBuffer()[0]);
 					}
 				} break;
 
@@ -175,8 +176,8 @@ uint8_t VDUStreamProcessor::createSampleFromBuffer(uint16_t bufferId, uint8_t fo
 		return 0;
 	}
 	clearSample(bufferId);
-	// create sample from buffer
 	auto sample = make_shared_psram<audio_sample>(buffers[bufferId], format);
+	// auto sample = make_shared_psram<audio_sample>(bufferId, format);
 	if (sample) {
 		samples[bufferId] = sample;
 		return 1;

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -825,7 +825,7 @@ void VDUStreamProcessor::bufferSplitInto(uint16_t bufferId, uint16_t length, std
 
 // VDU 23, 0, &A0, bufferId; &12, width; chunkCount; : Split buffer by width (in-place)
 // VDU 23, 0, &A0, bufferId; &13, width; <bufferIds>; 65535; : Split buffer by width to new buffers
-// VDU 23, 0, &A0, bufferId; &14, width; targetBufferId; : Split buffer by width to new buffers from ID onwards
+// VDU 23, 0, &A0, bufferId; &14, width; chunkCount; targetBufferId; : Split buffer by width to new buffers from ID onwards
 // Split a buffer into multiple blocks/streams to new buffers/chunks by width
 // Will overwrite any existing buffers
 //

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -67,9 +67,11 @@ void VDUStreamProcessor::bufferWrite(uint16_t bufferId) {
 
 	debug_log("bufferWrite: storing stream into buffer %d, length %d\n\r", bufferId, length);
 
-	for (auto i = 0; i < length; i++) {
-		auto data = readByte_b();
-		bufferStream->writeBufferByte(data, i);
+	auto remaining = readIntoBuffer(bufferStream->getBuffer(), length);
+	if (remaining > 0) {
+		// NB this discards the data we just read
+		debug_log("bufferWrite: timed out write for buffer %d (%d bytes remaining)\n\r", bufferId, remaining);
+		return;
 	}
 
 	buffers[bufferId].push_back(std::move(bufferStream));

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -7,12 +7,11 @@
 #include <unordered_map>
 
 #include "agon.h"
+#include "buffers.h"
 #include "buffer_stream.h"
 #include "multi_buffer_stream.h"
 #include "sprites.h"
 #include "types.h"
-
-std::unordered_map<uint16_t, std::vector<std::shared_ptr<BufferStream>>> buffers;
 
 // VDU 23, 0, &A0, bufferId; command: Buffered command support
 //

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -246,6 +246,7 @@ void VDUStreamProcessor::bufferClear(uint16_t bufferId) {
 	}
 	buffers.erase(bufferId);
 	clearBitmap(bufferId);
+	clearSample(bufferId);
 	debug_log("bufferClear: cleared buffer %d\n\r", bufferId);
 }
 

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -8,6 +8,7 @@
 #include "agon.h"
 #include "buffer_stream.h"
 #include "multi_buffer_stream.h"
+#include "sprites.h"
 #include "types.h"
 
 std::unordered_map<uint16_t, std::vector<std::shared_ptr<BufferStream>, psram_allocator<std::shared_ptr<BufferStream>>>> buffers;
@@ -144,10 +145,12 @@ void VDUStreamProcessor::bufferClear(uint16_t bufferId) {
 	debug_log("bufferClear: buffer %d\n\r", bufferId);
 	if (bufferId == 65535) {
 		buffers.clear();
+		resetBitmaps();
 		return;
 	}
 	if (buffers.find(bufferId) != buffers.end()) {
 		buffers.erase(bufferId);
+		clearBitmap(bufferId);
 		debug_log("bufferClear: cleared buffer %d\n\r", bufferId);
 	} else {
 		debug_log("bufferClear: buffer %d not found\n\r", bufferId);

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -485,14 +485,18 @@ bool VDUStreamProcessor::bufferConditional() {
 //
 void VDUStreamProcessor::bufferJump(uint16_t bufferId) {
 	debug_log("bufferJump: buffer %d\n\r", bufferId);
-	if (bufferId == 65535) {
-		// buffer ID of -1 (65535) is used as a "null output" stream
-		return;
-	}
 	if (id == 65535) {
 		// we're currently the top-level stream, so we can't jump
 		// so have to call instead
 		bufferCall(bufferId);
+		return;
+	}
+	if (bufferId == 65535) {
+		// buffer ID of -1 (65535) is used as a "null output" stream
+		// for a jump it indicates "go to end of stream"
+		// this will return out a called stream
+		auto instream = (MultiBufferStream *)inputStream.get();
+		instream->seekTo(instream->size());
 		return;
 	}
 	if (bufferId == id) {

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -70,6 +70,9 @@ void VDUStreamProcessor::vdu_sys_buffered() {
 		}	break;
 		case BUFFERED_DEBUG_INFO: {
 			debug_log("vdu_sys_buffered: buffer %d, %d streams stored\n\r", bufferId, buffers[bufferId].size());
+			if (buffers[bufferId].size() == 0) {
+				return;
+			}
 			// output contents of buffer stream 0
 			auto buffer = buffers[bufferId][0];
 			auto bufferLength = buffer->size();

--- a/video/vdu_sprites.h
+++ b/video/vdu_sprites.h
@@ -3,6 +3,7 @@
 
 #include <fabgl.h>
 
+#include "buffers.h"
 #include "graphics.h"
 #include "sprites.h"
 #include "types.h"

--- a/video/vdu_sprites.h
+++ b/video/vdu_sprites.h
@@ -146,11 +146,10 @@ void VDUStreamProcessor::vdu_sys_sprites(void) {
 		}	break;
 
 		case 0x21: {	// Create bitmap from buffer
-			auto bufferId = readWord_t(); if (bufferId == -1) return;
-			auto format = readByte_t(); if (format == -1) return;
 			auto width = readWord_t(); if (width == -1) return;
 			auto height = readWord_t(); if (height == -1) return;
-			createBitmapFromBuffer(bufferId, format, width, height);
+			auto format = readByte_t(); if (format == -1) return;
+			createBitmapFromBuffer(getCurrentBitmapId(), format, width, height);
 		}	break;
 
 		case 0x26: {	// add sprite frame for bitmap (long ID)

--- a/video/vdu_sprites.h
+++ b/video/vdu_sprites.h
@@ -6,7 +6,6 @@
 #include "graphics.h"
 #include "sprites.h"
 #include "types.h"
-#include "vdu_stream_processor.h"
 
 // Sprite Engine, VDU command handler
 //

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -62,7 +62,7 @@ class VDUStreamProcessor {
 
 		void vdu_sys_buffered();
 		uint32_t bufferWrite(uint16_t bufferId, uint32_t size);
-		void bufferCall(uint16_t bufferId);
+		void bufferCall(uint16_t bufferId, uint32_t offset);
 		void bufferClear(uint16_t bufferId);
 		std::shared_ptr<WritableBufferStream> bufferCreate(uint16_t bufferId, uint32_t size);
 		void setOutputStream(uint16_t bufferId);
@@ -71,7 +71,7 @@ class VDUStreamProcessor {
 		bool setBufferByte(uint8_t value, uint16_t bufferId, uint32_t offset);
 		void bufferAdjust(uint16_t bufferId);
 		bool bufferConditional();
-		void bufferJump(uint16_t bufferId);
+		void bufferJump(uint16_t bufferId, uint32_t offset);
 		void bufferCopy(uint16_t bufferId);
 		void bufferConsolidate(uint16_t bufferId);
 		void bufferSplit(uint16_t bufferId, uint16_t length);

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -67,14 +67,17 @@ class VDUStreamProcessor {
 		std::shared_ptr<WritableBufferStream> bufferCreate(uint16_t bufferId, uint32_t size);
 		void setOutputStream(uint16_t bufferId);
 		uint32_t getOffsetFromStream(uint16_t bufferId, bool isAdvanced);
+		std::vector<uint16_t> getBufferIdsFromStream();
 		int16_t getBufferByte(uint16_t bufferId, uint32_t offset);
 		bool setBufferByte(uint8_t value, uint16_t bufferId, uint32_t offset);
 		void bufferAdjust(uint16_t bufferId);
 		bool bufferConditional();
 		void bufferJump(uint16_t bufferId, uint32_t offset);
-		void bufferCopy(uint16_t bufferId);
+		void bufferCopy(uint16_t bufferId, std::vector<uint16_t> sourceBufferIds);
 		void bufferConsolidate(uint16_t bufferId);
-		void bufferSplit(uint16_t bufferId, uint16_t length);
+		void bufferSplitInto(uint16_t bufferId, uint16_t length, std::vector<uint16_t> newBufferIds, bool iterate);
+		void bufferSplitByInto(uint16_t bufferId, uint16_t width, uint16_t chunkCount, std::vector<uint16_t> newBufferIds, bool iterate);
+		void bufferSpreadInto(uint16_t bufferId, std::vector<uint16_t> newBufferIds, bool iterate);
 		void bufferReverseBlocks(uint16_t bufferId);
 		void bufferReverse(uint16_t bufferId, uint8_t options);
 

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -102,6 +102,7 @@ class VDUStreamProcessor {
 		void bufferConsolidate(uint16_t bufferId);
 		void bufferSplit(uint16_t bufferId, uint16_t length);
 		void bufferReverseBlocks(uint16_t bufferId);
+		void bufferReverse(uint16_t bufferId, uint8_t options);
 };
 
 // Read an unsigned byte from the serial port, with a timeout

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -86,15 +86,18 @@ class VDUStreamProcessor {
 		void sendKeycodeByte(uint8_t b, bool waitack);
 
 		void vdu_sys_buffered();
-		void bufferWrite(uint16_t bufferId);
+		void bufferWrite(uint16_t bufferId, uint32_t size);
 		void bufferCall(uint16_t bufferId);
 		void bufferClear(uint16_t bufferId);
-		void bufferCreate(uint16_t bufferId);
+		void bufferCreate(uint16_t bufferId, uint32_t size);
 		void setOutputStream(uint16_t bufferId);
 		int16_t getBufferByte(uint16_t bufferId, uint32_t offset);
 		bool setBufferByte(uint8_t value, uint16_t bufferId, uint32_t offset);
 		void bufferAdjust(uint16_t bufferId);
-		void bufferConditionalCall(uint16_t bufferId);
+		bool bufferConditional();
+		void bufferJump(uint16_t bufferId);
+		void bufferCopy(uint16_t bufferId);
+		void bufferConsolidate(uint16_t bufferId);
 };
 
 // Read an unsigned byte from the serial port, with a timeout

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -81,6 +81,7 @@ class VDUStreamProcessor {
 
 		void vdu_sys_sprites(void);
 		void receiveBitmap(uint8_t cmd, uint16_t width, uint16_t height);
+		void createBitmapFromBuffer(uint16_t bufferId, uint8_t format, uint16_t width, uint16_t height);
 
 		void vdu_sys_hexload(void);
 		void sendKeycodeByte(uint8_t b, bool waitack);

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -66,6 +66,7 @@ class VDUStreamProcessor {
 		void bufferClear(uint16_t bufferId);
 		std::shared_ptr<WritableBufferStream> bufferCreate(uint16_t bufferId, uint32_t size);
 		void setOutputStream(uint16_t bufferId);
+		uint32_t getOffsetFromStream(uint16_t bufferId, bool isAdvanced);
 		int16_t getBufferByte(uint16_t bufferId, uint32_t offset);
 		bool setBufferByte(uint8_t value, uint16_t bufferId, uint32_t offset);
 		void bufferAdjust(uint16_t bufferId);

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -49,7 +49,8 @@ class VDUStreamProcessor {
 
 		void vdu_sys_audio();
 		void sendAudioStatus(uint8_t channel, uint8_t status);
-		uint8_t loadSample(uint8_t sampleIndex, uint32_t length);
+		uint8_t loadSample(uint16_t bufferId, uint32_t length);
+		uint8_t createSampleFromBuffer(uint16_t bufferId, uint8_t format);
 		void setVolumeEnvelope(uint8_t channel, uint8_t type);
 		void setFrequencyEnvelope(uint8_t channel, uint8_t type);
 

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -9,33 +9,6 @@
 #include "types.h"
 
 class VDUStreamProcessor {
-	public:
-		VDUStreamProcessor(std::shared_ptr<Stream> inputStream, std::shared_ptr<Stream> outputStream, uint16_t bufferId) :
-			inputStream(inputStream), outputStream(outputStream), originalOutputStream(outputStream), id(bufferId) {}
-		VDUStreamProcessor(Stream *input) :
-			inputStream(std::shared_ptr<Stream>(input)), outputStream(inputStream), originalOutputStream(inputStream) {}
-		inline bool byteAvailable() {
-			return inputStream->available() > 0;
-		}
-		inline uint8_t readByte() {
-			return inputStream->read();
-		}
-		inline void writeByte(uint8_t b) {
-			if (outputStream) {
-				outputStream->write(b);
-			}
-		}
-		void send_packet(uint8_t code, uint16_t len, uint8_t data[]);
-
-		void processAllAvailable();
-		void processNext();
-
-		void vdu(uint8_t c);
-
-		void wait_eZ80();
-		void sendModeInformation();
-
-		uint16_t id = 65535;
 	private:
 		std::shared_ptr<Stream> inputStream;
 		std::shared_ptr<Stream> outputStream;
@@ -103,6 +76,35 @@ class VDUStreamProcessor {
 		void bufferSplit(uint16_t bufferId, uint16_t length);
 		void bufferReverseBlocks(uint16_t bufferId);
 		void bufferReverse(uint16_t bufferId, uint8_t options);
+
+	public:
+		uint16_t id = 65535;
+
+		VDUStreamProcessor(std::shared_ptr<Stream> input, std::shared_ptr<Stream> output, uint16_t bufferId) :
+			inputStream(input), outputStream(output), originalOutputStream(output), id(bufferId) {}
+		VDUStreamProcessor(Stream *input) :
+			inputStream(std::shared_ptr<Stream>(input)), outputStream(inputStream), originalOutputStream(inputStream) {}
+
+		inline bool byteAvailable() {
+			return inputStream->available() > 0;
+		}
+		inline uint8_t readByte() {
+			return inputStream->read();
+		}
+		inline void writeByte(uint8_t b) {
+			if (outputStream) {
+				outputStream->write(b);
+			}
+		}
+		void send_packet(uint8_t code, uint16_t len, uint8_t data[]);
+
+		void processAllAvailable();
+		void processNext();
+
+		void vdu(uint8_t c);
+
+		void wait_eZ80();
+		void sendModeInformation();
 };
 
 // Read an unsigned byte from the serial port, with a timeout

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -100,6 +100,8 @@ class VDUStreamProcessor {
 		void bufferJump(uint16_t bufferId);
 		void bufferCopy(uint16_t bufferId);
 		void bufferConsolidate(uint16_t bufferId);
+		void bufferSplit(uint16_t bufferId, uint16_t length);
+		void bufferReverseBlocks(uint16_t bufferId);
 };
 
 // Read an unsigned byte from the serial port, with a timeout

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -5,6 +5,7 @@
 #include <Stream.h>
 
 #include "agon.h"
+#include "buffer_stream.h"
 #include "types.h"
 
 class VDUStreamProcessor {
@@ -87,10 +88,10 @@ class VDUStreamProcessor {
 		void sendKeycodeByte(uint8_t b, bool waitack);
 
 		void vdu_sys_buffered();
-		void bufferWrite(uint16_t bufferId, uint32_t size);
+		uint32_t bufferWrite(uint16_t bufferId, uint32_t size);
 		void bufferCall(uint16_t bufferId);
 		void bufferClear(uint16_t bufferId);
-		void bufferCreate(uint16_t bufferId, uint32_t size);
+		std::shared_ptr<WritableBufferStream> bufferCreate(uint16_t bufferId, uint32_t size);
 		void setOutputStream(uint16_t bufferId);
 		int16_t getBufferByte(uint16_t bufferId, uint32_t offset);
 		bool setBufferByte(uint8_t value, uint16_t bufferId, uint32_t offset);
@@ -163,6 +164,10 @@ uint8_t VDUStreamProcessor::readByte_b() {
 //
 uint32_t VDUStreamProcessor::readIntoBuffer(uint8_t * buffer, uint32_t length, uint16_t timeout = COMMS_TIMEOUT) {
 	uint32_t remaining = length;
+	if (buffer == nullptr) {
+		debug_log("readIntoBuffer: buffer is null\n\r");
+		return remaining;
+	}
 	auto t = xTaskGetTickCountFromISR();
 	auto now = t;
 	auto timeCheck = pdMS_TO_TICKS(timeout);

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -163,9 +163,13 @@ void VDUStreamProcessor::vdu_sys_video() {
 // VDU 23, 0, &80, <echo>: Send a general poll/echo byte back to MOS
 //
 void VDUStreamProcessor::sendGeneralPoll() {
-	auto b = readByte_b();
+	auto b = readByte_t();
+	if (b == -1) {
+		debug_log("sendGeneralPoll: Timeout\n\r");
+		return;
+	}
 	uint8_t packet[] = {
-		b,
+		(uint8_t) (b & 0xFF),
 	};
 	send_packet(PACKET_GP, sizeof packet, packet);
 	initialised = true;	


### PR DESCRIPTION
This PR changes the bitmap system to leverage the buffered commands API.  All bitmaps are now stored in buffers accessible thru the buffered commands API.  Firstly this lets more than 256 bitmaps be stored on the VDP, and secondly it allows for bitmaps to be processed/edited on the VDP, reducing the need to process bitmaps on the ez80 and allowing for some cool new features.

Similar changes have now also been made to the audio system.

As part of this work, the buffered commands API also gains a bunch of new commands.  Many of these new commands are around copying, buffers, splitting them into blocks, consolidating blocks within buffers, and reversing data within buffers.  These calls can be incredibly useful when dealing with bitmaps.  At a really simple level they can allow a bitmap to be mirrored in either (or both) of the X and Y axis.  They can also be used to split a sprite sheet into individual bitmaps.  Existing commands can be used to modify bitmaps in other ways

As well as these data manipulation commands, there is now also a variety of "jump" commands, including jumping to offsets within a buffer.

Some preliminary information on these additions can be found against AgonConsole8/agon-vdp#61

The buffered commands documentation will get updated with more information, and more examples soon.  (That may take some time.)

Builds on #104 