### PR TITLE
Support more keyboard layouts

### DIFF
--- a/video/agon_keyboard.h
+++ b/video/agon_keyboard.h
@@ -40,6 +40,13 @@ void setKeyboardLayout(uint8_t region) {
 		case 6:	kb->setLayout(&fabgl::BelgianLayout); break;
 		case 7:	kb->setLayout(&fabgl::NorwegianLayout); break;
 		case 8:	kb->setLayout(&fabgl::JapaneseLayout);break;
+    case 9: kb->setLayout(&fabgl::USInternationalLayout);break;
+    case 10: kb->setLayout(&fabgl::USInternationalAltLayout);break;
+    case 11: kb->setLayout(&fabgl::SwissGLayout);break;
+    case 12: kb->setLayout(&fabgl::SwissFLayout);break;
+    case 13: kb->setLayout(&fabgl::DanishLayout);break;
+    case 14: kb->setLayout(&fabgl::SwedishLayout);break;
+    case 15: kb->setLayout(&fabgl::PortugueseLayout);break;
 		default:
 			kb->setLayout(&fabgl::UKLayout);
 			break;


### PR DESCRIPTION
This patch only compiles when combined with my PR to avalonbits/vdp-gl
The keyboard layouts themselves are in vdp-gl, this file allows you to select them.

Needs a fix to MOS as MOS *set KEYBOARD n checks n<9 
But we can do VDU 23,0,129,n instead.

