### PR TITLE
Support "zero duration" sample playback

### DIFF
--- a/video/audio_channel.h
+++ b/video/audio_channel.h
@@ -78,6 +78,17 @@ uint8_t audio_channel::play_note(uint8_t volume, uint16_t frequency, int32_t dur
 			this->_volume = volume;
 			this->_frequency = frequency;
 			this->_duration = duration == 65535 ? -1 : duration;
+			if (this->_duration == 0 && this->_waveformType == AUDIO_WAVE_SAMPLE) {
+				// zero duration means play whole sample
+				this->_duration = ((EnhancedSamplesGenerator *)this->_waveform.get())->getDuration();
+				if (this->_volumeEnvelope) {
+					// subtract the "release" time from the duration
+					this->_duration -= this->_volumeEnvelope->getRelease();
+				}
+				if (this->_duration < 0) {
+					this->_duration = 1;
+				}
+			}
 			this->_state = AUDIO_STATE_PENDING;
 			debug_log("audio_driver: play_note %d,%d,%d,%d\n\r", this->_channel, this->_volume, this->_frequency, this->_duration);
 			return 1;

--- a/video/audio_sample.h
+++ b/video/audio_sample.h
@@ -25,6 +25,13 @@ struct audio_sample {
 			index = 0;
 		}
 	}
+	uint32_t getDuration() {
+		uint32_t duration = 0;
+		for (auto block : blocks) {
+			duration += block->size();
+		}
+		return duration / 16;
+	}
 	std::vector<std::shared_ptr<BufferStream>>& blocks;
 	uint8_t			format;			// Format of the sample data
 	uint32_t		index;			// Current index inside the current sample block

--- a/video/enhanced_samples_generator.h
+++ b/video/enhanced_samples_generator.h
@@ -59,7 +59,7 @@ int EnhancedSamplesGenerator::getSample() {
 
 int EnhancedSamplesGenerator::getDuration() {
 	// NB this is hard-coded for a 16khz sample rate
-	return _sample.expired() ? 0 : _sample.lock()->length / 16;
+	return _sample.expired() ? 0 : _sample.lock()->getDuration();
 }
 
 #endif // ENHANCED_SAMPLES_GENERATOR_H

--- a/video/enhanced_samples_generator.h
+++ b/video/enhanced_samples_generator.h
@@ -17,6 +17,8 @@ class EnhancedSamplesGenerator : public WaveformGenerator {
 
 		void setFrequency(int value);
 		int getSample();
+
+		int getDuration();
 	
 	private:
 		std::weak_ptr<audio_sample> _sample;
@@ -53,6 +55,11 @@ int EnhancedSamplesGenerator::getSample() {
 	decDuration();
 
 	return sample;
+}
+
+int EnhancedSamplesGenerator::getDuration() {
+	// NB this is hard-coded for a 16khz sample rate
+	return _sample.expired() ? 0 : _sample.lock()->length / 16;
 }
 
 #endif // ENHANCED_SAMPLES_GENERATOR_H

--- a/video/envelopes/frequency.h
+++ b/video/envelopes/frequency.h
@@ -12,8 +12,8 @@
 
 class FrequencyEnvelope {
 	public:
-		virtual uint16_t getFrequency(uint16_t baseFrequency, uint32_t elapsed, int32_t duration);
-		virtual bool isFinished(uint32_t elapsed, int32_t duration);
+		virtual uint16_t getFrequency(uint16_t baseFrequency, uint32_t elapsed, int32_t duration) = 0;
+		virtual bool isFinished(uint32_t elapsed, int32_t duration) = 0;
 };
 
 struct FrequencyStepPhase {

--- a/video/envelopes/volume.h
+++ b/video/envelopes/volume.h
@@ -9,9 +9,9 @@
 
 class VolumeEnvelope {
 	public:
-		virtual uint8_t getVolume(uint8_t baseVolume, uint32_t elapsed, int32_t duration);
-		virtual bool isReleasing(uint32_t elapsed, int32_t duration);
-		virtual bool isFinished(uint32_t elapsed, int32_t duration);
+		virtual uint8_t getVolume(uint8_t baseVolume, uint32_t elapsed, int32_t duration) = 0;
+		virtual bool isReleasing(uint32_t elapsed, int32_t duration) = 0;
+		virtual bool isFinished(uint32_t elapsed, int32_t duration) = 0;
 };
 
 class ADSRVolumeEnvelope : public VolumeEnvelope {

--- a/video/envelopes/volume.h
+++ b/video/envelopes/volume.h
@@ -12,6 +12,7 @@ class VolumeEnvelope {
 		virtual uint8_t getVolume(uint8_t baseVolume, uint32_t elapsed, int32_t duration) = 0;
 		virtual bool isReleasing(uint32_t elapsed, int32_t duration) = 0;
 		virtual bool isFinished(uint32_t elapsed, int32_t duration) = 0;
+		virtual uint16_t getRelease() = 0;
 };
 
 class ADSRVolumeEnvelope : public VolumeEnvelope {
@@ -20,6 +21,9 @@ class ADSRVolumeEnvelope : public VolumeEnvelope {
 		uint8_t getVolume(uint8_t baseVolume, uint32_t elapsed, int32_t duration);
 		bool isReleasing(uint32_t elapsed, int32_t duration);
 		bool isFinished(uint32_t elapsed, int32_t duration);
+		uint16_t getRelease() {
+			return this->_release;
+		}
 	private:
 		uint16_t _attack;
 		uint16_t _decay;


### PR DESCRIPTION
Adds support for "play note" on a channel that has a sound sample applied to it to accept a duration of zero to indicate that the whole sample should be played.

This is a convenience to make it easier to play entire samples.  Without it you need to keep track of how long a sample is when attempting to play it.

In the event that a sample is set on a channel that _also_ has a volume envelope applied, the actual note playback duration will be the longer of the sample length or the release phase of the envelope.  (If necessary, the sample will loop until the release phase has completed)