### PR TITLE
Add platformio support.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,25 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = video
+
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+lib_deps =
+    https://github.com/avalonbits/vdp-gl.git#1.0.3
+    fbiego/ESP32Time@^2.0.0
+build_flags =
+    -DBOARD_HAS_PSRAM
+    -mfix-esp32-psram-cache-issue
+monitor_speed = 115200
+upload_speed = 600000

--- a/video/video.ino
+++ b/video/video.ino
@@ -44,6 +44,7 @@
 // 05/09/2023:					+ New audio enhancements, improved mode change code
 // 12/09/2023:					+ Refactored
 
+#include <WiFi.h>
 #include <HardwareSerial.h>
 #include <fabgl.h>
 


### PR DESCRIPTION
This adds platformio (https://platformio.org/) support without breaking the compatibility with arduino IDE.