### PR TITLE
Semantic versioning

### DIFF
--- a/video/version.h
+++ b/video/version.h
@@ -1,0 +1,12 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+#define		VERSION_MAJOR		2
+#define		VERSION_MINOR		0
+#define		VERSION_PATCH		0
+#define		VERSION_CANDIDATE	1			// Optional
+#define		VERSION_TYPE		"Alpha "	// RC, Alpha, Beta, etc.
+
+#define		VERSION_VARIANT		"Quark"
+
+#endif // VERSION_H

--- a/video/video.ino
+++ b/video/video.ino
@@ -47,15 +47,12 @@
 #include <HardwareSerial.h>
 #include <fabgl.h>
 
-#define VERSION			1
-#define REVISION		4
-#define RC				2
-
 #define	DEBUG			0						// Serial Debug Mode: 1 = enable
 #define SERIALKB		0						// Serial Keyboard: 1 = enable (Experimental)
 #define SERIALBAUDRATE	115200
 
 #include "agon.h"								// Configuration file
+#include "version.h"							// Version information
 #include "agon_keyboard.h"						// Keyboard support
 #include "agon_audio.h"							// Audio support
 #include "agon_ttxt.h"
@@ -163,9 +160,13 @@ void do_keyboard_terminal() {
 // The boot screen
 //
 void boot_screen() {
-	printFmt("Agon Quark VDP Version %d.%02d", VERSION, REVISION);
-	#if RC > 0
-		printFmt(" RC%d", RC);
+	printFmt("Agon %s VDP Version %d.%d.%d", VERSION_VARIANT, VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH);
+	#if VERSION_CANDIDATE > 0
+		printFmt(" %s%d", VERSION_TYPE, VERSION_CANDIDATE);
+	#endif
+	// Show build if defined (intended to be auto-generated string from build script from git commit hash)
+	#ifdef VERSION_BUILD
+		printFmt(" Build %s", VERSION_BUILD);
 	#endif
 	printFmt("\n\r");
 }


### PR DESCRIPTION
I've moved the AgonConsole8 fork of agon-vdp to use semantic versioning.  

There's several reasons why.  On other projects I've used CI tooling that will do things like automatically increment version numbers and create new releases when new commits get pushed to `main`, and at some point I'd like to implement that.

Another reason is that I think it would be good for us to make more frequent releases.  By having "major.minor.patch" it feels like the stakes are lower for cutting a new release that contains only patch changes.  It's also not such a big deal to add in new minor features.

This PR sets the version at "2.0.0 Alpha 1".  This is a straw-man number.  Given that there has been quite a lot of changes made since the last full release, and this moves to a new version numbering system it feels like a justifiable number.


From the commit message:

move version info out to `version.h` file.

version info now a semantic version, with major, minor, patch, and “candidate” info, as well as an indicator for candidate type (displayed if candidate number is non-zero)

support for showing an automatically-generated build number added, which can be provided by a build script and is intended to be derived from the git hash

with this approach it should also be possible in the future to add other tooling to automatically increment version numbers

version info also includes the codebase variant, allowing us to easily differentiate between Quark and Console8
