### PR TITLE
some updater improvements

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -46,11 +46,10 @@
 #define VDP_KEYSTATE			0x88	// Keyboard repeat rate and LED status
 #define VDP_MOUSE				0x89	// Mouse data
 #define VDP_BUFFERED			0xA0	// Buffered commands
+#define VDP_UPDATER				0xA1	// Update VDP
 #define VDP_LOGICALCOORDS		0xC0	// Switch BBC Micro style logical coords on and off
 #define VDP_LEGACYMODES			0xC1	// Switch VDP 1.03 compatible modes on and off
 #define VDP_SWITCHBUFFER		0xC3	// Double buffering control
-#define VDP_UPDATE				0xD0	// Update VDP
-#define VDP_SWITCH				0xD1	// Switch VDP
 #define VDP_TERMINALMODE		0xFF	// Switch to terminal mode
 
 // And the corresponding return packets

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -93,9 +93,6 @@ void VDUStreamProcessor::vdu_sys() {
 			case 0x1C: {					// VDU 23, 28
 				vdu_sys_hexload();
 			}	break;
-			case 0x1D: {					// VDU 23, 29
-				vdu_sys_updater();
-			}	break;
 		}
 	}
 	//
@@ -151,6 +148,9 @@ void VDUStreamProcessor::vdu_sys_video() {
 		}	break;
 		case VDP_BUFFERED: {			// VDU 23, 0, &A0, bufferId; command, <args>
 			vdu_sys_buffered();
+		}	break;
+		case VDP_UPDATER: {				// VDU 23, 0, &A1, command, <args>
+			vdu_sys_updater();
 		}	break;
 		case VDP_LOGICALCOORDS: {		// VDU 23, 0, &C0, n
 			auto b = readByte_t();		// Set logical coord mode


### PR DESCRIPTION
Apologies @breakintoprogram  - I had spotted a couple of minor issues with the updater code that I had been discussing with @astralaster but neglected to put a note against his PR on your repo.

The changes here are as follows:

shifts the updater command to sit under VDU 23,0,&A1.  commands under VDU 23,0 are intended to program the VDP hardware, so this is a better fit for these commands

improved handling of failure cases within the updater code.  failures to initiate the OTA system, or write OTA data should now discard serial data correctly and abort the update process