### PR TITLE
fixes a triangle plot issue

### DIFF
--- a/video/graphics.h
+++ b/video/graphics.h
@@ -333,6 +333,7 @@ void plotTriangle() {
 		p2,
 		p1, 
 	};
+	canvas->drawPath(p, 3);
 	canvas->fillPath(p, 3);
 }
 
@@ -351,6 +352,7 @@ void plotParallelogram() {
 		p1,
 		Point(p1.X + (p3.X - p2.X), p1.Y + (p3.Y - p2.Y)),
 	};
+	canvas->drawPath(p, 4);
 	canvas->fillPath(p, 4);
 }
 


### PR DESCRIPTION
fab-gl’s canvas drawing routine for triangles when only using `fillPath` doesn’t _quite_ fill out the same pixels as plain line drawing.  this change ensures that filled triangles cover the same pixels as an equivalent line-drawn triangle

change also applied to parallelogram, since that draws in the same manner as triangles.

fixes #113 