### PR TITLE
add support for bitmap PLOT code

### DIFF
--- a/video/graphics.h
+++ b/video/graphics.h
@@ -419,6 +419,12 @@ void plotCopyMove(uint8_t mode) {
 	}
 }
 
+// Plot bitmap
+//
+void plotBitmap() {
+	drawBitmap(p1.X, p1.Y);
+}
+
 // Character plot
 //
 void plotCharacter(char c) {

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -261,6 +261,9 @@ void VDUStreamProcessor::vdu_plot() {
 					// fab-gl's ellipse isn't compatible with BBC BASIC
 					debug_log("plot ellipse not implemented\n\r");
 					break;
+				case 0xE8:	// Bitmap plot
+					plotBitmap();
+					break;
 			}
 			break;
 	}


### PR DESCRIPTION
Plot codes in the range of &E8-EF in Acorn’s GXR are for plotting the currently selected bitmap.  this PR adds support for that.

this allows bitmaps to be plotted using OS coordinates