### PR TITLE
Allow frequency changes on audio samples

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,8 +19,8 @@ board_build.f_cpu = 240000000L
 board_build.f_flash = 80000000L
 framework = arduino
 lib_deps =
-    https://github.com/avalonbits/vdp-gl.git#1.0.3
-    fbiego/ESP32Time@^2.0.0
+    https://github.com/avalonbits/vdp-gl.git#1.0.4
+    fbiego/ESP32Time@^2.0.4
 build_flags =
     -DBOARD_HAS_PSRAM
     -mfix-esp32-psram-cache-issue

--- a/video/audio_channel.h
+++ b/video/audio_channel.h
@@ -334,9 +334,8 @@ void audio_channel::loop() {
 			if (this->_waveformType == AUDIO_WAVE_SAMPLE) {
 				// hack to ensure samples always start from beginning
 				this->_waveform->setFrequency(-1);
-			} else {
-				this->_waveform->setFrequency(this->getFrequency(0));
 			}
+			this->_waveform->setFrequency(this->getFrequency(0));
 			this->_waveform->enable(true);
 			// if we have an envelope then we loop, otherwise just delay for duration			
 			if (this->_volumeEnvelope || this->_frequencyEnvelope) {


### PR DESCRIPTION
I've made some small changes to allow SetFrequency to work for audio samples.  This is done by keeping track of the previous and current samples and having a "fractional" offset which works its way through the samples at a non-integer rate.  This fractional offset is then used to interpolate between the two samples either side.

The rate is calculated by "desired frequency / baseFrequency" and this is added on to the fractional offset every time a sample is requested.  Whenever this becomes greater than 1, the next sample is fetched and it's decremented by one (repeatedly until it's below 1 again in the case of very high frequencies).

I hope you will consider this change, or I hope it prompts you to implement something else to allow for playing back samples at different rates, because I think this is a very useful feature to have.

This is my first collaboration on another open source project, and my first "pull" request, so I hope I've done everything correctly!