### PR TITLE
fix bitmap plot screen location

### DIFF
--- a/video/graphics.h
+++ b/video/graphics.h
@@ -423,7 +423,7 @@ void plotCopyMove(uint8_t mode) {
 // Plot bitmap
 //
 void plotBitmap() {
-	drawBitmap(p1.X, p1.Y);
+	drawBitmap(p1.X, p1.Y, true);
 }
 
 // Character plot

--- a/video/sprites.h
+++ b/video/sprites.h
@@ -43,7 +43,7 @@ inline uint16_t getCurrentBitmapId() {
 void drawBitmap(uint16_t x, uint16_t y) {
 	auto bitmap = getBitmap();
 	if (bitmap) {
-		canvas->drawBitmap(x, y, bitmap.get());
+		canvas->drawBitmap(x, logicalCoords ? y - bitmap->height : y, bitmap.get());
 	} else {
 		debug_log("drawBitmap: bitmap %d not found\n\r", currentBitmap);
 	}

--- a/video/sprites.h
+++ b/video/sprites.h
@@ -40,10 +40,10 @@ inline uint16_t getCurrentBitmapId() {
 	return currentBitmap;
 }
 
-void drawBitmap(uint16_t x, uint16_t y) {
+void drawBitmap(uint16_t x, uint16_t y, bool compensateHeight = false) {
 	auto bitmap = getBitmap();
 	if (bitmap) {
-		canvas->drawBitmap(x, logicalCoords ? y - bitmap->height : y, bitmap.get());
+		canvas->drawBitmap(x, (compensateHeight && logicalCoords) ? y - bitmap->height : y, bitmap.get());
 	} else {
 		debug_log("drawBitmap: bitmap %d not found\n\r", currentBitmap);
 	}

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -263,7 +263,7 @@ void VDUStreamProcessor::bufferClear(uint16_t bufferId) {
 // This is used for creating buffers to redirect output to
 //
 std::shared_ptr<WritableBufferStream> VDUStreamProcessor::bufferCreate(uint16_t bufferId, uint32_t size) {
-	if (bufferId == 0 || bufferId == 65535) {
+	if (bufferId == 65535) {
 		debug_log("bufferCreate: bufferId %d is reserved\n\r", bufferId);
 		return nullptr;
 	}


### PR DESCRIPTION
the recently added bitmap plot code was always plotting based on the top-left corner of the bitmap.  when using OS coordinates this is incorrect behaviour - plot location should be based on the bottom-left corner, as per Acorn GXR

this fixes that behaviour