### PR TITLE
Adjustable sample-rate and frequency shifting on samples

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -68,6 +68,7 @@
 #define PACKET_MOUSE			0x09	// Mouse data
 
 #define AUDIO_CHANNELS			3		// Default number of audio channels
+#define AUDIO_DEFAULT_SAMPLE_RATE	FABGL_SOUNDGEN_DEFAULT_SAMPLE_RATE	// Default sample rate
 #define MAX_AUDIO_CHANNELS		32		// Maximum number of audio channels
 #define PLAY_SOUND_PRIORITY		3		// Sound driver task priority with 3 (configMAX_PRIORITIES - 1) being the highest, and 0 being the lowest
 
@@ -102,6 +103,8 @@
 
 #define AUDIO_FORMAT_8BIT_SIGNED	0	// 8-bit signed sample
 #define AUDIO_FORMAT_8BIT_UNSIGNED	1	// 8-bit unsigned sample
+#define AUDIO_FORMAT_DATA_MASK		7	// data bit mask for format
+#define AUDIO_FORMAT_WITH_RATE		8	// OR this with the format to indicate a sample rate follows
 
 #define AUDIO_ENVELOPE_NONE		0		// No envelope
 #define AUDIO_ENVELOPE_ADSR		1		// Simple ADSR volume envelope

--- a/video/agon.h
+++ b/video/agon.h
@@ -118,12 +118,14 @@
 #define AUDIO_STATUS_HAS_VOLUME_ENVELOPE	0x08	// Channel has a volume envelope set
 #define AUDIO_STATUS_HAS_FREQUENCY_ENVELOPE	0x10	// Channel has a frequency envelope set
 
-#define AUDIO_STATE_IDLE		0		// Channel is idle/silent
-#define AUDIO_STATE_PENDING		1		// Channel is pending (note will be played next loop call)
-#define AUDIO_STATE_PLAYING		2		// Channel is playing a note (passive)
-#define AUDIO_STATE_PLAY_LOOP	3		// Channel is in active note playing loop
-#define AUDIO_STATE_RELEASE		4		// Channel is releasing a note
-#define AUDIO_STATE_ABORT		5		// Channel is aborting a note
+enum AudioState : uint8_t {	// Audio channel state
+	Idle = 0,				// currently idle/silent
+	Pending,				// note will be played next loop call
+	Playing,				// playing (passive)
+	PlayLoop,				// active playing loop (used when an envelope is active)
+	Release,				// in "release" phase
+	Abort					// aborting a note
+};
 
 // Mouse commands
 #define MOUSE_ENABLE			0		// Enable mouse

--- a/video/agon.h
+++ b/video/agon.h
@@ -98,9 +98,14 @@
 
 #define AUDIO_SAMPLE_LOAD		0		// Send a sample to the VDP
 #define AUDIO_SAMPLE_CLEAR		1		// Clear/delete a sample
-#define AUDIO_SAMPLE_FROM_BUFFER	2	// Load a sample from a buffer
-#define AUDIO_SAMPLE_SET_FREQUENCY	3	// Set the base frequency of a sample
-#define AUDIO_SAMPLE_BUFFER_SET_FREQUENCY	4	// Set the base frequency of a sample (using buffer ID)
+#define AUDIO_SAMPLE_FROM_BUFFER				2	// Load a sample from a buffer
+#define AUDIO_SAMPLE_SET_FREQUENCY				3	// Set the base frequency of a sample
+#define AUDIO_SAMPLE_BUFFER_SET_FREQUENCY		4	// Set the base frequency of a sample (using buffer ID)
+#define AUDIO_SAMPLE_SET_REPEAT_START			5	// Set the repeat start point of a sample
+#define AUDIO_SAMPLE_BUFFER_SET_REPEAT_START	6	// Set the repeat start point of a sample (using buffer ID)
+#define AUDIO_SAMPLE_SET_REPEAT_LENGTH			7	// Set the repeat length of a sample
+#define AUDIO_SAMPLE_BUFFER_SET_REPEAT_LENGTH	8	// Set the repeat length of a sample (using buffer ID)
+#define AUDIO_SAMPLE_SEEK						9	// Seek to a position in a sample
 #define AUDIO_SAMPLE_DEBUG_INFO 0x10	// Get debug info about a sample
 
 #define AUDIO_DEFAULT_FREQUENCY	523		// Default sample frequency (C5, or C above middle C)

--- a/video/agon.h
+++ b/video/agon.h
@@ -85,6 +85,7 @@
 #define AUDIO_CMD_ENABLE		8		// Enables a channel
 #define AUDIO_CMD_DISABLE		9		// Disables (destroys) a channel
 #define AUDIO_CMD_RESET			10		// Reset audio channel
+#define AUDIO_CMD_SEEK			11		// Seek to a position in a sample
 
 #define AUDIO_WAVE_DEFAULT		0		// Default waveform (Square wave)
 #define AUDIO_WAVE_SQUARE		0		// Square wave
@@ -105,7 +106,6 @@
 #define AUDIO_SAMPLE_BUFFER_SET_REPEAT_START	6	// Set the repeat start point of a sample (using buffer ID)
 #define AUDIO_SAMPLE_SET_REPEAT_LENGTH			7	// Set the repeat length of a sample
 #define AUDIO_SAMPLE_BUFFER_SET_REPEAT_LENGTH	8	// Set the repeat length of a sample (using buffer ID)
-#define AUDIO_SAMPLE_SEEK						9	// Seek to a position in a sample
 #define AUDIO_SAMPLE_DEBUG_INFO 0x10	// Get debug info about a sample
 
 #define AUDIO_DEFAULT_FREQUENCY	523		// Default sample frequency (C5, or C above middle C)

--- a/video/agon.h
+++ b/video/agon.h
@@ -68,7 +68,7 @@
 #define PACKET_MOUSE			0x09	// Mouse data
 
 #define AUDIO_CHANNELS			3		// Default number of audio channels
-#define AUDIO_DEFAULT_SAMPLE_RATE	FABGL_SOUNDGEN_DEFAULT_SAMPLE_RATE	// Default sample rate
+#define AUDIO_DEFAULT_SAMPLE_RATE	16384	// Default sample rate
 #define MAX_AUDIO_CHANNELS		32		// Maximum number of audio channels
 #define PLAY_SOUND_PRIORITY		3		// Sound driver task priority with 3 (configMAX_PRIORITIES - 1) being the highest, and 0 being the lowest
 

--- a/video/agon.h
+++ b/video/agon.h
@@ -86,6 +86,7 @@
 #define AUDIO_CMD_DISABLE		9		// Disables (destroys) a channel
 #define AUDIO_CMD_RESET			10		// Reset audio channel
 #define AUDIO_CMD_SEEK			11		// Seek to a position in a sample
+#define AUDIO_CMD_DURATION		12		// Set the duration of a channel
 
 #define AUDIO_WAVE_DEFAULT		0		// Default waveform (Square wave)
 #define AUDIO_WAVE_SQUARE		0		// Square wave

--- a/video/agon.h
+++ b/video/agon.h
@@ -99,9 +99,11 @@
 #define AUDIO_SAMPLE_LOAD		0		// Send a sample to the VDP
 #define AUDIO_SAMPLE_CLEAR		1		// Clear/delete a sample
 #define AUDIO_SAMPLE_FROM_BUFFER	2	// Load a sample from a buffer
+#define AUDIO_SAMPLE_SET_FREQUENCY	3	// Set the base frequency of a sample
+#define AUDIO_SAMPLE_BUFFER_SET_FREQUENCY	4	// Set the base frequency of a sample (using buffer ID)
 #define AUDIO_SAMPLE_DEBUG_INFO 0x10	// Get debug info about a sample
 
-#define AUDIO_DEFAULT_FREQUENCY	523	// Default sample frequency (C5, or C above middle C)
+#define AUDIO_DEFAULT_FREQUENCY	523		// Default sample frequency (C5, or C above middle C)
 
 #define AUDIO_FORMAT_8BIT_SIGNED	0	// 8-bit signed sample
 #define AUDIO_FORMAT_8BIT_UNSIGNED	1	// 8-bit unsigned sample

--- a/video/agon.h
+++ b/video/agon.h
@@ -107,6 +107,7 @@
 #define AUDIO_FORMAT_8BIT_UNSIGNED	1	// 8-bit unsigned sample
 #define AUDIO_FORMAT_DATA_MASK		7	// data bit mask for format
 #define AUDIO_FORMAT_WITH_RATE		8	// OR this with the format to indicate a sample rate follows
+#define AUDIO_FORMAT_TUNEABLE		16	// OR this with the format to indicate sample can be tuned (frequency adjustable)
 
 #define AUDIO_ENVELOPE_NONE		0		// No envelope
 #define AUDIO_ENVELOPE_ADSR		1		// Simple ADSR volume envelope

--- a/video/agon.h
+++ b/video/agon.h
@@ -101,6 +101,8 @@
 #define AUDIO_SAMPLE_FROM_BUFFER	2	// Load a sample from a buffer
 #define AUDIO_SAMPLE_DEBUG_INFO 0x10	// Get debug info about a sample
 
+#define AUDIO_DEFAULT_FREQUENCY	523	// Default sample frequency (C5, or C above middle C)
+
 #define AUDIO_FORMAT_8BIT_SIGNED	0	// 8-bit signed sample
 #define AUDIO_FORMAT_8BIT_UNSIGNED	1	// 8-bit unsigned sample
 #define AUDIO_FORMAT_DATA_MASK		7	// data bit mask for format

--- a/video/agon.h
+++ b/video/agon.h
@@ -87,6 +87,7 @@
 #define AUDIO_CMD_RESET			10		// Reset audio channel
 #define AUDIO_CMD_SEEK			11		// Seek to a position in a sample
 #define AUDIO_CMD_DURATION		12		// Set the duration of a channel
+#define AUDIO_CMD_SAMPLERATE	13		// Set the samplerate for channel or underlying audio system
 
 #define AUDIO_WAVE_DEFAULT		0		// Default waveform (Square wave)
 #define AUDIO_WAVE_SQUARE		0		// Square wave

--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -73,12 +73,12 @@ void setSampleRate(uint16_t sampleRate) {
 	if (sampleRate == 65535) {
 		sampleRate = AUDIO_DEFAULT_SAMPLE_RATE;
 	}
-	// detatch the old sound generator
+	// detach the old sound generator
 	if (soundGenerator) {
 		soundGenerator->play(false);
 		for (auto channelPair : audioChannels) {
 			auto channel = channelPair.second;
-			soundGenerator->detach(channel->getWaveform());
+			channel->detachSoundGenerator();
 		}
 	}
 	// delete the old sound generator
@@ -160,7 +160,7 @@ uint8_t clearSample(uint16_t sampleId) {
 		debug_log("clearSample: sample %d not found\n\r", sampleId);
 		return 0;
 	}
-	samples.erase(sampleId);
+	samples[sampleId] = nullptr;
 	debug_log("reset sample\n\r");
 	return 1;
 }

--- a/video/agon_audio.h
+++ b/video/agon_audio.h
@@ -69,7 +69,7 @@ void audioTaskKill(uint8_t channel) {
 // Initialise the sound driver
 //
 void initAudio() {
-	soundGenerator = std::make_shared<fabgl::SoundGenerator>();
+	soundGenerator = std::make_shared<fabgl::SoundGenerator>(AUDIO_DEFAULT_SAMPLE_RATE);
 	audioHandlers.reserve(MAX_AUDIO_CHANNELS);
 	debug_log("initAudio: we have reserved %d channels\n\r", audioHandlers.capacity());
 	for (uint8_t i = 0; i < AUDIO_CHANNELS; i++) {

--- a/video/audio_channel.h
+++ b/video/audio_channel.h
@@ -80,8 +80,9 @@ uint8_t AudioChannel::playNote(uint8_t volume, uint16_t frequency, int32_t durat
 			this->_duration = duration == 65535 ? -1 : duration;
 			if (this->_duration == 0 && this->_waveformType == AUDIO_WAVE_SAMPLE) {
 				// zero duration means play whole sample
-				// TODO duration needs to be flexible for streamed samples where total buffer size is unknown
-				this->_duration = ((EnhancedSamplesGenerator *)this->_waveform.get())->getDuration();
+				// NB this can only work out sample duration based on sample provided
+				// so if sample data is streaming in an explicit length should be used instead
+				this->_duration = ((EnhancedSamplesGenerator *)this->_waveform.get())->getDuration(frequency);
 				if (this->_volumeEnvelope) {
 					// subtract the "release" time from the duration
 					this->_duration -= this->_volumeEnvelope->getRelease();

--- a/video/audio_channel.h
+++ b/video/audio_channel.h
@@ -27,6 +27,7 @@ class AudioChannel {
 		void		setFrequency(uint16_t frequency);
 		void		setVolumeEnvelope(std::unique_ptr<VolumeEnvelope> envelope);
 		void		setFrequencyEnvelope(std::unique_ptr<FrequencyEnvelope> envelope);
+		void		seekTo(uint32_t position);
 		void		loop();
 		uint8_t		channel() { return _channel; }
 	private:
@@ -284,6 +285,12 @@ void AudioChannel::setFrequencyEnvelope(std::unique_ptr<FrequencyEnvelope> envel
 	}
 }
 
+void AudioChannel::seekTo(uint32_t position) {
+	if (this->_waveformType == AUDIO_WAVE_SAMPLE) {
+		((EnhancedSamplesGenerator *)this->_waveform.get())->seekTo(position);
+	}
+}
+
 void AudioChannel::waitForAbort() {
 	while (this->_state == AudioState::Abort) {
 		// wait for abort to complete
@@ -333,10 +340,7 @@ void AudioChannel::loop() {
 			this->_startTime = millis();
 			// set our initial volume and frequency
 			this->_waveform->setVolume(this->getVolume(0));
-			if (this->_waveformType == AUDIO_WAVE_SAMPLE) {
-				// hack to ensure samples always start from beginning
-				this->_waveform->setFrequency(-1);
-			}
+			this->seekTo(0);
 			this->_waveform->setFrequency(this->getFrequency(0));
 			this->_waveform->enable(true);
 			// if we have an envelope then we loop, otherwise just delay for duration			

--- a/video/audio_channel.h
+++ b/video/audio_channel.h
@@ -80,6 +80,7 @@ uint8_t AudioChannel::playNote(uint8_t volume, uint16_t frequency, int32_t durat
 			this->_duration = duration == 65535 ? -1 : duration;
 			if (this->_duration == 0 && this->_waveformType == AUDIO_WAVE_SAMPLE) {
 				// zero duration means play whole sample
+				// TODO duration needs to be flexible for streamed samples where total buffer size is unknown
 				this->_duration = ((EnhancedSamplesGenerator *)this->_waveform.get())->getDuration();
 				if (this->_volumeEnvelope) {
 					// subtract the "release" time from the duration

--- a/video/audio_channel.h
+++ b/video/audio_channel.h
@@ -334,9 +334,8 @@ void audio_channel::loop() {
 			if (this->_waveformType == AUDIO_WAVE_SAMPLE) {
 				// hack to ensure samples always start from beginning
 				this->_waveform->setFrequency(-1);
-			} else {
-				this->_waveform->setFrequency(this->getFrequency(0));
 			}
+			this->_waveform->setFrequency(this->getFrequency(0));
 			this->_waveform->enable(true);
 			// if we have an envelope then we loop, otherwise just delay for duration			
 			if (this->_volumeEnvelope || this->_frequencyEnvelope) {

--- a/video/audio_channel.h
+++ b/video/audio_channel.h
@@ -201,7 +201,7 @@ void AudioChannel::setWaveform(int8_t waveformType, std::shared_ptr<AudioChannel
 		}
 		this->_waveform = std::move(newWaveform);
 		_waveformType = waveformType;
-		soundGenerator->attach(this->_waveform.get());
+		attachSoundGenerator();
 		debug_log("AudioChannel: setWaveform %d done\n\r", waveformType);
 	}
 }

--- a/video/audio_channel.h
+++ b/video/audio_channel.h
@@ -2,6 +2,7 @@
 #define AUDIO_CHANNEL_H
 
 #include <memory>
+#include <atomic>
 #include <unordered_map>
 #include <fabgl.h>
 
@@ -30,24 +31,25 @@ class AudioChannel {
 		void		setSampleRate(uint16_t sampleRate);
 		WaveformGenerator * getWaveform() { return this->_waveform.get(); }
 		void		attachSoundGenerator();
+		void		detachSoundGenerator();
 		void		seekTo(uint32_t position);
 		void		loop();
 		uint8_t		channel() { return _channel; }
 	private:
-		std::unique_ptr<fabgl::WaveformGenerator>	getSampleWaveform(uint16_t sampleId, std::shared_ptr<AudioChannel> channelRef);
+		std::shared_ptr<WaveformGenerator>	getSampleWaveform(uint16_t sampleId, std::shared_ptr<AudioChannel> channelRef);
 		void		waitForAbort();
 		uint8_t		getVolume(uint32_t elapsed);
 		uint16_t	getFrequency(uint32_t elapsed);
 		bool		isReleasing(uint32_t elapsed);
 		bool		isFinished(uint32_t elapsed);
-		AudioState	_state;
 		uint8_t		_channel;
 		uint8_t		_volume;
 		uint16_t	_frequency;
 		int32_t		_duration;
 		uint32_t	_startTime;
 		uint8_t		_waveformType;
-		std::unique_ptr<WaveformGenerator>	_waveform;
+		std::atomic<AudioState>				_state;
+		std::shared_ptr<WaveformGenerator>	_waveform = nullptr;
 		std::unique_ptr<VolumeEnvelope>		_volumeEnvelope;
 		std::unique_ptr<FrequencyEnvelope>	_frequencyEnvelope;
 };
@@ -56,27 +58,26 @@ class AudioChannel {
 #include "enhanced_samples_generator.h"
 extern std::unordered_map<uint16_t, std::shared_ptr<AudioSample>> samples;	// Storage for the sample data
 
-AudioChannel::AudioChannel(uint8_t channel) {
-	this->_channel = channel;
-	this->_state = AudioState::Idle;
-	this->_volume = 64;
-	this->_frequency = 750;
-	this->_duration = -1;
+AudioChannel::AudioChannel(uint8_t channel) : _channel(channel), _state(AudioState::Idle), _volume(64), _frequency(750), _duration(-1) {
 	setWaveform(AUDIO_WAVE_DEFAULT, nullptr);
-	debug_log("AudioChannel: init %d\n\r", this->_channel);
+	debug_log("AudioChannel: init %d\n\r", channel);
 	debug_log("free mem: %d\n\r", heap_caps_get_free_size(MALLOC_CAP_8BIT));
 }
 
 AudioChannel::~AudioChannel() {
-	debug_log("AudioChannel: deiniting %d\n\r", this->_channel);
+	debug_log("AudioChannel: deiniting %d\n\r", channel());
 	if (this->_waveform) {
 		this->_waveform->enable(false);
-		soundGenerator->detach(this->_waveform.get());
+		soundGenerator->detach(getWaveform());
 	}
-	debug_log("AudioChannel: deinit %d\n\r", this->_channel);
+	debug_log("AudioChannel: deinit %d\n\r", channel());
 }
 
 uint8_t AudioChannel::playNote(uint8_t volume, uint16_t frequency, int32_t duration) {
+	if (!this->_waveform) {
+		debug_log("AudioChannel: no waveform on channel %d\n\r", channel());
+		return 0;
+	}
 	switch (this->_state) {
 		case AudioState::Idle:
 		case AudioState::Release:
@@ -87,7 +88,7 @@ uint8_t AudioChannel::playNote(uint8_t volume, uint16_t frequency, int32_t durat
 				// zero duration means play whole sample
 				// NB this can only work out sample duration based on sample provided
 				// so if sample data is streaming in an explicit length should be used instead
-				this->_duration = ((EnhancedSamplesGenerator *)this->_waveform.get())->getDuration(frequency);
+				this->_duration = ((EnhancedSamplesGenerator *)getWaveform())->getDuration(frequency);
 				if (this->_volumeEnvelope) {
 					// subtract the "release" time from the duration
 					this->_duration -= this->_volumeEnvelope->getRelease();
@@ -97,7 +98,7 @@ uint8_t AudioChannel::playNote(uint8_t volume, uint16_t frequency, int32_t durat
 				}
 			}
 			this->_state = AudioState::Pending;
-			debug_log("AudioChannel: playNote %d,%d,%d,%d\n\r", this->_channel, this->_volume, this->_frequency, this->_duration);
+			debug_log("AudioChannel: playNote %d,%d,%d,%d\n\r", channel(), volume, frequency, this->_duration);
 			return 1;
 	}
 	return 0;
@@ -129,47 +130,54 @@ uint8_t AudioChannel::getStatus() {
 	return status;
 }
 
-std::unique_ptr<fabgl::WaveformGenerator> AudioChannel::getSampleWaveform(uint16_t sampleId, std::shared_ptr<AudioChannel> channelRef) {
+std::shared_ptr<WaveformGenerator> AudioChannel::getSampleWaveform(uint16_t sampleId, std::shared_ptr<AudioChannel> channelRef) {
 	if (samples.find(sampleId) != samples.end()) {
 		auto sample = samples.at(sampleId);
-		// remove this channel from other samples
-		for (auto samplePair : samples) {
-			if (samplePair.second) {
-				samplePair.second->channels.erase(_channel);
-			}
-		}
-		sample->channels[_channel] = channelRef;
+		// if (sample->channels.find(_channel) != sample->channels.end()) {
+		// 	// this channel is already playing this sample, so do nothing
+		// 	debug_log("AudioChannel: already playing sample %d on channel %d\n\r", sampleId, channel());
+		// 	return nullptr;
+		// }
 
-		return make_unique_psram<EnhancedSamplesGenerator>(sample);
+		// TODO remove channel tracking??
+		// remove this channel from other samples
+		// for (auto samplePair : samples) {
+		// 	if (samplePair.second) {
+		// 		samplePair.second->channels.erase(_channel);
+		// 	}
+		// }
+		// sample->channels[_channel] = channelRef;
+
+		return std::make_shared<EnhancedSamplesGenerator>(sample);
 	}
 	return nullptr;
 }
 
 void AudioChannel::setWaveform(int8_t waveformType, std::shared_ptr<AudioChannel> channelRef, uint16_t sampleId) {
-	std::unique_ptr<fabgl::WaveformGenerator> newWaveform = nullptr;
+	std::shared_ptr<WaveformGenerator> newWaveform = nullptr;
 
 	switch (waveformType) {
 		case AUDIO_WAVE_SAWTOOTH:
-			newWaveform = make_unique_psram<SawtoothWaveformGenerator>();
+			newWaveform = std::make_shared<SawtoothWaveformGenerator>();
 			break;
 		case AUDIO_WAVE_SQUARE:
-			newWaveform = make_unique_psram<SquareWaveformGenerator>();
+			newWaveform = std::make_shared<SquareWaveformGenerator>();
 			break;
 		case AUDIO_WAVE_SINE:
-			newWaveform = make_unique_psram<SineWaveformGenerator>();
+			newWaveform = std::make_shared<SineWaveformGenerator>();
 			break;
 		case AUDIO_WAVE_TRIANGLE:
-			newWaveform = make_unique_psram<TriangleWaveformGenerator>();
+			newWaveform = std::make_shared<TriangleWaveformGenerator>();
 			break;
 		case AUDIO_WAVE_NOISE:
-			newWaveform = make_unique_psram<NoiseWaveformGenerator>();
+			newWaveform = std::make_shared<NoiseWaveformGenerator>();
 			break;
 		case AUDIO_WAVE_VICNOISE:
-			newWaveform = make_unique_psram<VICNoiseGenerator>();
+			newWaveform = std::make_shared<VICNoiseGenerator>();
 			break;
 		case AUDIO_WAVE_SAMPLE:
 			// Buffer-based sample playback
-			debug_log("AudioChannel: using sample buffer %d for waveform\n\r", sampleId);
+			debug_log("AudioChannel: using sample buffer %d for waveform on channel %d\n\r", sampleId, channel());
 			newWaveform = getSampleWaveform(sampleId, channelRef);
 			break;
 		default:
@@ -177,17 +185,17 @@ void AudioChannel::setWaveform(int8_t waveformType, std::shared_ptr<AudioChannel
 			if (waveformType < 0) {
 				// convert our negative sample number to a positive sample number starting at our base buffer ID
 				int16_t sampleNum = BUFFERED_SAMPLE_BASEID + (-waveformType - 1);
-				debug_log("AudioChannel: using sample %d for waveform (%d)\n\r", waveformType, sampleNum);
+				debug_log("AudioChannel: using sample %d for waveform (%d) on channel %d\n\r", waveformType, sampleNum, channel());
 				newWaveform = getSampleWaveform(sampleNum, channelRef);
 				waveformType = AUDIO_WAVE_SAMPLE;
 			} else {
-				debug_log("AudioChannel: unknown waveform type %d\n\r", waveformType);
+				debug_log("AudioChannel: unknown waveform type %d on channel %d\n\r", waveformType, channel());
 			}
 			break;
 	}
 
-	if (newWaveform != nullptr) {
-		debug_log("AudioChannel: setWaveform %d\n\r", waveformType);
+	if (newWaveform) {
+		debug_log("AudioChannel: setWaveform %d on channel %d\n\r", waveformType, channel());
 		if (this->_state != AudioState::Idle) {
 			debug_log("AudioChannel: aborting current playback\n\r");
 			// some kind of playback is happening, so abort any current task delay to allow playback to end
@@ -197,17 +205,17 @@ void AudioChannel::setWaveform(int8_t waveformType, std::shared_ptr<AudioChannel
 		}
 		if (this->_waveform) {
 			debug_log("AudioChannel: detaching old waveform\n\r");
-			soundGenerator->detach(this->_waveform.get());
+			detachSoundGenerator();
 		}
-		this->_waveform = std::move(newWaveform);
+		this->_waveform = newWaveform;
 		_waveformType = waveformType;
 		attachSoundGenerator();
-		debug_log("AudioChannel: setWaveform %d done\n\r", waveformType);
+		debug_log("AudioChannel: setWaveform %d done on channel %d\n\r", waveformType, channel());
 	}
 }
 
 void AudioChannel::setVolume(uint8_t volume) {
-	debug_log("AudioChannel: setVolume %d\n\r", volume);
+	debug_log("AudioChannel: setVolume %d on channel %d\n\r", volume, channel());
 
 	if (this->_waveform) {
 		waitForAbort();
@@ -254,7 +262,7 @@ void AudioChannel::setVolume(uint8_t volume) {
 }
 
 void AudioChannel::setFrequency(uint16_t frequency) {
-	debug_log("AudioChannel: setFrequency %d\n\r", frequency);
+	debug_log("AudioChannel: setFrequency %d on channel %d\n\r", frequency, channel());
 	this->_frequency = frequency;
 
 	if (this->_waveform) {
@@ -272,7 +280,7 @@ void AudioChannel::setFrequency(uint16_t frequency) {
 }
 
 void AudioChannel::setDuration(int32_t duration) {
-	debug_log("AudioChannel: setDuration %d\n\r", duration);
+	debug_log("AudioChannel: setDuration %d on channel %d\n\r", duration, channel());
 	if (duration == 0xFFFFFF) {
 		duration = -1;
 	}
@@ -321,13 +329,19 @@ void AudioChannel::setSampleRate(uint16_t sampleRate) {
 
 void AudioChannel::attachSoundGenerator() {
 	if (this->_waveform) {
-		soundGenerator->attach(this->_waveform.get());
+		soundGenerator->attach(getWaveform());
+	}
+}
+
+void AudioChannel::detachSoundGenerator() {
+	if (this->_waveform) {
+		soundGenerator->detach(getWaveform());
 	}
 }
 
 void AudioChannel::seekTo(uint32_t position) {
 	if (this->_waveformType == AUDIO_WAVE_SAMPLE) {
-		((EnhancedSamplesGenerator *)this->_waveform.get())->seekTo(position);
+		((EnhancedSamplesGenerator *)getWaveform())->seekTo(position);
 	}
 }
 
@@ -373,9 +387,11 @@ bool AudioChannel::isFinished(uint32_t elapsed) {
 }
 
 void AudioChannel::loop() {
+	int delay = 0;
+
 	switch (this->_state) {
 		case AudioState::Pending:
-			debug_log("AudioChannel: play %d,%d,%d,%d\n\r", this->_channel, this->_volume, this->_frequency, this->_duration);
+			debug_log("AudioChannel: play %d,%d,%d,%d\n\r", channel(), this->_volume, this->_frequency, this->_duration);
 			// we have a new note to play
 			this->_startTime = millis();
 			// set our initial volume and frequency
@@ -389,33 +405,35 @@ void AudioChannel::loop() {
 			} else {
 				this->_state = AudioState::Playing;
 				// if delay value is negative then this delays for a super long time
-				vTaskDelay(pdMS_TO_TICKS(this->_duration));
+				delay = this->_duration;
 			}
 			break;
+
 		case AudioState::Playing:
 			if (this->_duration >= 0) {
 				// simple playback - delay until we have reached our duration
 				uint32_t elapsed = millis() - this->_startTime;
-				debug_log("AudioChannel: elapsed %d\n\r", elapsed);
+				debug_log("AudioChannel: %d elapsed %d\n\r", channel(), elapsed);
 				if (elapsed >= this->_duration) {
 					this->_waveform->enable(false);
-					debug_log("AudioChannel: end\n\r");
+					debug_log("AudioChannel: %d end\n\r", channel());
 					this->_state = AudioState::Idle;
 				} else {
-					debug_log("AudioChannel: loop (%d)\n\r", this->_duration - elapsed);
-					vTaskDelay(pdMS_TO_TICKS(this->_duration - elapsed));
+					debug_log("AudioChannel: %d loop (%d)\n\r", channel(), this->_duration - elapsed);
+					delay = this->_duration - elapsed;
 				}
 			} else {
 				// our duration is indefinite, so delay for a long time
-				debug_log("AudioChannel: loop (indefinite playback)\n\r");
-				vTaskDelay(pdMS_TO_TICKS(-1));
+				debug_log("AudioChannel: %d loop (indefinite playback)\n\r", channel());
+				delay = -1;
 			}
 			break;
+
 		// loop and release states used for envelopes
 		case AudioState::PlayLoop: {
 			uint32_t elapsed = millis() - this->_startTime;
 			if (isReleasing(elapsed)) {
-				debug_log("AudioChannel: releasing...\n\r");
+				debug_log("AudioChannel: releasing %d...\n\r", channel());
 				this->_state = AudioState::Release;
 			}
 			// update volume and frequency as appropriate
@@ -425,6 +443,7 @@ void AudioChannel::loop() {
 				this->_waveform->setFrequency(this->getFrequency(elapsed));
 			break;
 		}
+
 		case AudioState::Release: {
 			uint32_t elapsed = millis() - this->_startTime;
 			// update volume and frequency as appropriate
@@ -435,16 +454,21 @@ void AudioChannel::loop() {
 
 			if (isFinished(elapsed)) {
 				this->_waveform->enable(false);
-				debug_log("AudioChannel: end (released)\n\r");
+				debug_log("AudioChannel: end (released %d)\n\r", channel());
 				this->_state = AudioState::Idle;
 			}
 			break;
 		}
+
 		case AudioState::Abort:
 			this->_waveform->enable(false);
-			debug_log("AudioChannel: abort\n\r");
+			debug_log("AudioChannel: abort %d\n\r", channel());
 			this->_state = AudioState::Idle;
 			break;
+	}
+
+	if (delay != 0) {
+		vTaskDelay(pdMS_TO_TICKS(delay));
 	}
 }
 

--- a/video/audio_sample.h
+++ b/video/audio_sample.h
@@ -16,7 +16,6 @@ struct AudioSample {
 	int8_t getSample(uint32_t & index, uint32_t & blockIndex);
 	void seekTo(uint32_t position, uint32_t & index, uint32_t & blockIndex, int32_t & repeatCount);
 	uint32_t getSize();
-	uint32_t getDuration();
 
 	std::vector<std::shared_ptr<BufferStream>>& blocks;
 	uint8_t			format;				// Format of the sample data
@@ -92,11 +91,6 @@ uint32_t AudioSample::getSize() {
 		samples += block->size();
 	}
 	return samples;
-}
-
-uint32_t AudioSample::getDuration() {
-	// returns duration of sample in ms when played back without tuning
-	return (getSize() * 1000) / sampleRate;
 }
 
 #endif // AUDIO_SAMPLE_H

--- a/video/audio_sample.h
+++ b/video/audio_sample.h
@@ -10,21 +10,20 @@
 
 struct AudioSample {
 	AudioSample(std::vector<std::shared_ptr<BufferStream>>& streams, uint8_t format, uint32_t sampleRate = AUDIO_DEFAULT_SAMPLE_RATE, uint16_t frequency = 0) :
-		blocks(streams), format(format), sampleRate(sampleRate), baseFrequency(frequency), index(0), blockIndex(0) {}
+		blocks(streams), format(format), sampleRate(sampleRate), baseFrequency(frequency) {}
 	~AudioSample();
-	int8_t getSample();
-	void seekTo(uint32_t position);
+
+	int8_t getSample(uint32_t & index, uint32_t & blockIndex);
+	void seekTo(uint32_t position, uint32_t & index, uint32_t & blockIndex, int32_t & repeatCount);
 	uint32_t getSize();
 	uint32_t getDuration();
+
 	std::vector<std::shared_ptr<BufferStream>>& blocks;
 	uint8_t			format;				// Format of the sample data
-	uint32_t		index;				// Current index inside the current sample block
-	uint32_t		blockIndex;			// Current index into the sample data blocks
 	uint32_t		sampleRate;			// Sample rate of the sample
 	uint16_t		baseFrequency = 0;	// Base frequency of the sample
 	int32_t			repeatStart = 0;	// Start offset for repeat, in samples
 	int32_t			repeatLength = -1;	// Length of the repeat section in samples, -1 means to end of sample
-	int32_t			repeatCount = 0;	// Sample count when repeating
 	std::unordered_map<uint8_t, std::weak_ptr<AudioChannel>> channels;	// Channels playing this sample
 };
 
@@ -42,7 +41,7 @@ AudioSample::~AudioSample() {
 	debug_log("AudioSample cleared\n\r");
 }
 
-int8_t AudioSample::getSample() {
+int8_t AudioSample::getSample(uint32_t & index, uint32_t & blockIndex) {
 	// get the next sample
 	if (blockIndex >= blocks.size()) {
 		// we've reached the end of the sample, and haven't looped, so return 0 (silence)
@@ -51,13 +50,6 @@ int8_t AudioSample::getSample() {
 
 	auto block = blocks[blockIndex];
 	int8_t sample = block->getBuffer()[index++];
-	
-	// looping magic
-	repeatCount--;
-	if (repeatCount == 0) {
-		// we've reached the end of the repeat section, so loop back
-		seekTo(repeatStart);
-	}
 
 	if (index >= block->size()) {
 		// block reached end, move to next block
@@ -72,7 +64,7 @@ int8_t AudioSample::getSample() {
 	return sample;
 }
 
-void AudioSample::seekTo(uint32_t position) {
+void AudioSample::seekTo(uint32_t position, uint32_t & index, uint32_t & blockIndex, int32_t & repeatCount) {
 	// NB repeatCount calculation here can result in zero, or a negative number,
 	// or a number that's beyond the end of the sample, which is fine
 	// it just means that the sample will never loop

--- a/video/audio_sample.h
+++ b/video/audio_sample.h
@@ -9,7 +9,7 @@
 #include "buffer_stream.h"
 
 struct AudioSample {
-	AudioSample(std::vector<std::shared_ptr<BufferStream>>& streams, uint8_t format, uint32_t sampleRate = AUDIO_DEFAULT_SAMPLE_RATE, uint16_t frequency = AUDIO_DEFAULT_FREQUENCY) :
+	AudioSample(std::vector<std::shared_ptr<BufferStream>>& streams, uint8_t format, uint32_t sampleRate = AUDIO_DEFAULT_SAMPLE_RATE, uint16_t frequency = 0) :
 		blocks(streams), format(format), sampleRate(sampleRate), baseFrequency(frequency), index(0), blockIndex(0) {}
 	~AudioSample();
 	int8_t getSample();
@@ -27,6 +27,7 @@ struct AudioSample {
 		}
 	}
 	uint32_t getDuration() {
+		// TODO this needs to change to calculate duration with frequency borne in mind
 		uint32_t samples = 0;
 		for (auto block : blocks) {
 			samples += block->size();

--- a/video/audio_sample.h
+++ b/video/audio_sample.h
@@ -9,7 +9,7 @@
 #include "buffer_stream.h"
 
 struct AudioSample {
-	AudioSample(std::vector<std::shared_ptr<BufferStream>>& streams, uint8_t format, uint32_t sampleRate = AUDIO_DEFAULT_SAMPLE_RATE, uint16_t frequency = 0) :
+	AudioSample(std::vector<std::shared_ptr<BufferStream>> streams, uint8_t format, uint32_t sampleRate = AUDIO_DEFAULT_SAMPLE_RATE, uint16_t frequency = 0) :
 		blocks(streams), format(format), sampleRate(sampleRate), baseFrequency(frequency) {}
 	~AudioSample();
 
@@ -17,27 +17,26 @@ struct AudioSample {
 	void seekTo(uint32_t position, uint32_t & index, uint32_t & blockIndex, int32_t & repeatCount);
 	uint32_t getSize();
 
-	std::vector<std::shared_ptr<BufferStream>>& blocks;
+	std::vector<std::shared_ptr<BufferStream>> blocks;
 	uint8_t			format;				// Format of the sample data
 	uint32_t		sampleRate;			// Sample rate of the sample
 	uint16_t		baseFrequency = 0;	// Base frequency of the sample
 	int32_t			repeatStart = 0;	// Start offset for repeat, in samples
 	int32_t			repeatLength = -1;	// Length of the repeat section in samples, -1 means to end of sample
-	std::unordered_map<uint8_t, std::weak_ptr<AudioChannel>> channels;	// Channels playing this sample
+	// std::unordered_map<uint8_t, std::weak_ptr<AudioChannel>> channels;	// Channels playing this sample
 };
 
 AudioSample::~AudioSample() {
 	// iterate over channels
-	for (auto channelPair : this->channels) {
-		auto channelRef = channelPair.second;
-		if (!channelRef.expired()) {
-			auto channel = channelRef.lock();
-			debug_log("AudioSample: removing sample from channel %d\n\r", channel->channel());
-			// Remove sample from channel
-			channel->setWaveform(AUDIO_WAVE_DEFAULT, nullptr);
-		}
-	}
-	debug_log("AudioSample cleared\n\r");
+	// for (auto channelPair : this->channels) {
+	// 	auto channel = channelPair.second.lock();
+	// 	if (channel) {
+	// 		// Remove sample from channel
+	//		debug_log("AudioSample: removing sample from channel %d\n\r", channel->channel());
+	// 		// TODO change so only removes if channel is definitely set to this sample
+	// 		channel->setWaveform(AUDIO_WAVE_DEFAULT, nullptr);
+	// 	}
+	// }
 }
 
 int8_t AudioSample::getSample(uint32_t & index, uint32_t & blockIndex) {

--- a/video/audio_sample.h
+++ b/video/audio_sample.h
@@ -8,9 +8,9 @@
 #include "audio_channel.h"
 #include "buffer_stream.h"
 
-struct audio_sample {
-	audio_sample(std::vector<std::shared_ptr<BufferStream>>& streams, uint8_t format) : blocks(streams), format(format), index(0), blockIndex(0) {}
-	~audio_sample();
+struct AudioSample {
+	AudioSample(std::vector<std::shared_ptr<BufferStream>>& streams, uint8_t format) : blocks(streams), format(format), index(0), blockIndex(0) {}
+	~AudioSample();
 	int8_t getSample();
 	void rewind() {
 		index = 0;
@@ -36,24 +36,24 @@ struct audio_sample {
 	uint8_t			format;			// Format of the sample data
 	uint32_t		index;			// Current index inside the current sample block
 	uint32_t		blockIndex;		// Current index into the sample data blocks
-	std::unordered_map<uint8_t, std::weak_ptr<audio_channel>> channels;	// Channels playing this sample
+	std::unordered_map<uint8_t, std::weak_ptr<AudioChannel>> channels;	// Channels playing this sample
 };
 
-audio_sample::~audio_sample() {
+AudioSample::~AudioSample() {
 	// iterate over channels
 	for (auto channelPair : this->channels) {
 		auto channelRef = channelPair.second;
 		if (!channelRef.expired()) {
 			auto channel = channelRef.lock();
-			debug_log("audio_sample: removing sample from channel %d\n\r", channel->channel());
+			debug_log("AudioSample: removing sample from channel %d\n\r", channel->channel());
 			// Remove sample from channel
 			channel->setWaveform(AUDIO_WAVE_DEFAULT, nullptr);
 		}
 	}
-	debug_log("audio_sample cleared\n\r");
+	debug_log("AudioSample cleared\n\r");
 }
 
-int8_t audio_sample::getSample() {
+int8_t AudioSample::getSample() {
 	// our blocks might have changed, so we need to check if we're still in range
 	checkIndexes();
 

--- a/video/audio_sample.h
+++ b/video/audio_sample.h
@@ -9,7 +9,8 @@
 #include "buffer_stream.h"
 
 struct AudioSample {
-	AudioSample(std::vector<std::shared_ptr<BufferStream>>& streams, uint8_t format) : blocks(streams), format(format), index(0), blockIndex(0) {}
+	AudioSample(std::vector<std::shared_ptr<BufferStream>>& streams, uint8_t format, uint32_t sampleRate = AUDIO_DEFAULT_SAMPLE_RATE, uint16_t frequency = AUDIO_DEFAULT_FREQUENCY) :
+		blocks(streams), format(format), sampleRate(sampleRate), baseFrequency(frequency), index(0), blockIndex(0) {}
 	~AudioSample();
 	int8_t getSample();
 	void rewind() {
@@ -26,16 +27,18 @@ struct AudioSample {
 		}
 	}
 	uint32_t getDuration() {
-		uint32_t duration = 0;
+		uint32_t samples = 0;
 		for (auto block : blocks) {
-			duration += block->size();
+			samples += block->size();
 		}
-		return duration / 16;
+		return (samples * 1000) / sampleRate;
 	}
 	std::vector<std::shared_ptr<BufferStream>>& blocks;
 	uint8_t			format;			// Format of the sample data
 	uint32_t		index;			// Current index inside the current sample block
 	uint32_t		blockIndex;		// Current index into the sample data blocks
+	uint32_t		sampleRate;		// Sample rate of the sample
+	uint16_t		baseFrequency;	// Base frequency of the sample
 	std::unordered_map<uint8_t, std::weak_ptr<AudioChannel>> channels;	// Channels playing this sample
 };
 

--- a/video/enhanced_samples_generator.h
+++ b/video/enhanced_samples_generator.h
@@ -83,7 +83,10 @@ int EnhancedSamplesGenerator::getSample() {
 }
 
 int EnhancedSamplesGenerator::getDuration(uint16_t frequency) {
-	return _sample.expired() ? 0 : _sample.lock()->getDuration() / calculateSamplerate(frequency);
+	// TODO this will produce an incorrect duration if the sample rate for the channel has been
+	// adjusted to differ from the underlying audio system sample rate
+	// At this point it's not clear how to resolve this, so we'll assume it hasn't been adjusted
+	return _sample.expired() ? 0 : (_sample.lock()->getSize() * 1000 / sampleRate()) / calculateSamplerate(frequency);
 }
 
 void EnhancedSamplesGenerator::seekTo(uint32_t position) {

--- a/video/enhanced_samples_generator.h
+++ b/video/enhanced_samples_generator.h
@@ -33,12 +33,12 @@ EnhancedSamplesGenerator::EnhancedSamplesGenerator(std::shared_ptr<AudioSample> 
 	: _sample(sample)
 {}
 
-void EnhancedSamplesGenerator::setFrequency(int value) {
+void EnhancedSamplesGenerator::setFrequency(int frequency) {
 	// We'll hijack this method to allow us to reset the sample index
 	// ideally we'd override the enable method, but C++ doesn't let us do that
 	if (!_sample.expired()) {
 		auto samplePtr = _sample.lock();
-		if (value < 0) {
+		if (frequency < 0) {
 			// rewind our sample if it's still valid
 			samplePtr->rewind();
 
@@ -46,7 +46,7 @@ void EnhancedSamplesGenerator::setFrequency(int value) {
 			previousSample = samplePtr->getSample();
 			currentSample = samplePtr->getSample();
 		} else {
-			samplesPerGet = (double)value / (double)(samplePtr->sampleRate);
+			samplesPerGet = ((double)frequency / (double)samplePtr->baseFrequency) * ((double)samplePtr->sampleRate / (double)(AUDIO_DEFAULT_SAMPLE_RATE));
 		}
 	}
 }

--- a/video/enhanced_samples_generator.h
+++ b/video/enhanced_samples_generator.h
@@ -16,12 +16,12 @@ class EnhancedSamplesGenerator : public WaveformGenerator {
 		EnhancedSamplesGenerator(std::shared_ptr<AudioSample> sample);
 
 		void setFrequency(int value);
+		void setSampleRate(int value);
 		int getSample();
 
 		int getDuration(uint16_t frequency);
 
 		void seekTo(uint32_t position);
-
 	private:
 		std::weak_ptr<AudioSample> _sample;
 
@@ -31,6 +31,7 @@ class EnhancedSamplesGenerator : public WaveformGenerator {
 		// TODO consider whether repeatStart and repeatLength may need to be here
 		// which would allow for per-channel repeat settings
 
+		int				frequency = 0;
 		int				previousSample = 0;
 		int				currentSample = 0;
 		double			samplesPerGet = 1.0;
@@ -44,7 +45,13 @@ EnhancedSamplesGenerator::EnhancedSamplesGenerator(std::shared_ptr<AudioSample> 
 	: _sample(sample)
 {}
 
-void EnhancedSamplesGenerator::setFrequency(int frequency) {
+void EnhancedSamplesGenerator::setFrequency(int value) {
+	frequency = value;
+	samplesPerGet = calculateSamplerate(value);
+}
+
+void EnhancedSamplesGenerator::setSampleRate(int value) {
+	WaveformGenerator::setSampleRate(value);
 	samplesPerGet = calculateSamplerate(frequency);
 }
 
@@ -96,7 +103,7 @@ double EnhancedSamplesGenerator::calculateSamplerate(uint16_t frequency) {
 		auto samplePtr = _sample.lock();
 		auto baseFrequency = samplePtr->baseFrequency;
 		auto frequencyAdjust = baseFrequency > 0 ? (double)frequency / (double)baseFrequency : 1.0;
-		return frequencyAdjust * ((double)samplePtr->sampleRate / (double)(AUDIO_DEFAULT_SAMPLE_RATE));
+		return frequencyAdjust * ((double)samplePtr->sampleRate / (double)(sampleRate()));
 	}
 	return 1.0;
 }

--- a/video/enhanced_samples_generator.h
+++ b/video/enhanced_samples_generator.h
@@ -13,25 +13,25 @@
 //
 class EnhancedSamplesGenerator : public WaveformGenerator {
 	public:
-		EnhancedSamplesGenerator(std::shared_ptr<audio_sample> sample);
+		EnhancedSamplesGenerator(std::shared_ptr<AudioSample> sample);
 
 		void setFrequency(int value);
 		int getSample();
 
 		int getDuration();
-	
+
 	private:
-		std::weak_ptr<audio_sample> _sample;
+		std::weak_ptr<AudioSample> _sample;
 
-        int previousSample = 0;
-        int currentSample = 0;
-        double samplesPerGet = 1.0;
-        double fractionalSampleOffset = 0.0;
+		int previousSample = 0;
+		int currentSample = 0;
+		double samplesPerGet = 1.0;
+		double fractionalSampleOffset = 0.0;
 
-        const int baseFrequency = 16000;
+		const int baseFrequency = 16000;
 };
 
-EnhancedSamplesGenerator::EnhancedSamplesGenerator(std::shared_ptr<audio_sample> sample)
+EnhancedSamplesGenerator::EnhancedSamplesGenerator(std::shared_ptr<AudioSample> sample)
 	: _sample(sample)
 {}
 
@@ -44,14 +44,13 @@ void EnhancedSamplesGenerator::setFrequency(int value) {
 			auto samplePtr = _sample.lock();
 			samplePtr->rewind();
 
-            fractionalSampleOffset = 0.0;
-            previousSample = samplePtr->getSample();
-            currentSample = samplePtr->getSample();
+			fractionalSampleOffset = 0.0;
+			previousSample = samplePtr->getSample();
+			currentSample = samplePtr->getSample();
 		}
+	} else {
+		samplesPerGet = (double)value / (double)baseFrequency;
 	}
-    else {
-        samplesPerGet = (double)value / (double)baseFrequency;
-    }
 }
 
 int EnhancedSamplesGenerator::getSample() {
@@ -61,17 +60,16 @@ int EnhancedSamplesGenerator::getSample() {
 
 	auto samplePtr = _sample.lock();
 
-    while (fractionalSampleOffset >= 1.0)
-    {
-        previousSample = currentSample;
-    	currentSample = samplePtr->getSample();
-        fractionalSampleOffset -= 1.0;
-    }
+	while (fractionalSampleOffset >= 1.0) {
+		previousSample = currentSample;
+		currentSample = samplePtr->getSample();
+		fractionalSampleOffset -= 1.0;
+	}
 
-     // Interpolate between the samples to reduce aliasing
-    int sample = currentSample * fractionalSampleOffset + previousSample * (1.0-fractionalSampleOffset);
+	 // Interpolate between the samples to reduce aliasing
+	int sample = currentSample * fractionalSampleOffset + previousSample * (1.0-fractionalSampleOffset);
 
-    fractionalSampleOffset += samplesPerGet;
+	fractionalSampleOffset += samplesPerGet;
 
 	// process volume
 	sample = sample * volume() / 127;

--- a/video/enhanced_samples_generator.h
+++ b/video/enhanced_samples_generator.h
@@ -27,8 +27,6 @@ class EnhancedSamplesGenerator : public WaveformGenerator {
 		int currentSample = 0;
 		double samplesPerGet = 1.0;
 		double fractionalSampleOffset = 0.0;
-
-		const int baseFrequency = 16000;
 };
 
 EnhancedSamplesGenerator::EnhancedSamplesGenerator(std::shared_ptr<AudioSample> sample)
@@ -38,18 +36,18 @@ EnhancedSamplesGenerator::EnhancedSamplesGenerator(std::shared_ptr<AudioSample> 
 void EnhancedSamplesGenerator::setFrequency(int value) {
 	// We'll hijack this method to allow us to reset the sample index
 	// ideally we'd override the enable method, but C++ doesn't let us do that
-	if (value < 0) {
-		// rewind our sample if it's still valid
-		if (!_sample.expired()) {
-			auto samplePtr = _sample.lock();
+	if (!_sample.expired()) {
+		auto samplePtr = _sample.lock();
+		if (value < 0) {
+			// rewind our sample if it's still valid
 			samplePtr->rewind();
 
 			fractionalSampleOffset = 0.0;
 			previousSample = samplePtr->getSample();
 			currentSample = samplePtr->getSample();
+		} else {
+			samplesPerGet = (double)value / (double)(samplePtr->sampleRate);
 		}
-	} else {
-		samplesPerGet = (double)value / (double)baseFrequency;
 	}
 }
 

--- a/video/enhanced_samples_generator.h
+++ b/video/enhanced_samples_generator.h
@@ -23,26 +23,26 @@ class EnhancedSamplesGenerator : public WaveformGenerator {
 
 		void seekTo(uint32_t position);
 	private:
-		std::weak_ptr<AudioSample> _sample;
+		std::shared_ptr<AudioSample> _sample;
 
-		uint32_t		index;				// Current index inside the current sample block
-		uint32_t		blockIndex;			// Current index into the sample data blocks
-		int32_t			repeatCount = 0;	// Sample count when repeating
+		uint32_t	index;				// Current index inside the current sample block
+		uint32_t	blockIndex;			// Current index into the sample data blocks
+		int32_t		repeatCount;		// Sample count when repeating
 		// TODO consider whether repeatStart and repeatLength may need to be here
 		// which would allow for per-channel repeat settings
 
-		int				frequency = 0;
-		int				previousSample = 0;
-		int				currentSample = 0;
-		double			samplesPerGet = 1.0;
-		double			fractionalSampleOffset = 0.0;
+		int			frequency;
+		int			previousSample;
+		int			currentSample;
+		double		samplesPerGet;
+		double		fractionalSampleOffset;
 
 		double calculateSamplerate(uint16_t frequency);
 		int8_t getNextSample();
 };
 
 EnhancedSamplesGenerator::EnhancedSamplesGenerator(std::shared_ptr<AudioSample> sample)
-	: _sample(sample)
+	: _sample(sample), repeatCount(0), index(0), blockIndex(0), frequency(0), previousSample(0), currentSample(0), samplesPerGet(1.0), fractionalSampleOffset(0.0)
 {}
 
 void EnhancedSamplesGenerator::setFrequency(int value) {
@@ -56,23 +56,21 @@ void EnhancedSamplesGenerator::setSampleRate(int value) {
 }
 
 int EnhancedSamplesGenerator::getSample() {
-	if (duration() == 0 || _sample.expired()) {
+	if (duration() == 0) {
 		return 0;
 	}
-
-	auto samplePtr = _sample.lock();
 
 	// if we've moved far enough along, read the next sample
 	while (fractionalSampleOffset >= 1.0) {
 		previousSample = currentSample;
 		currentSample = getNextSample();
-		fractionalSampleOffset -= 1.0;
+		fractionalSampleOffset = fractionalSampleOffset - 1.0;
 	}
 
 	 // Interpolate between the samples to reduce aliasing
 	int sample = currentSample * fractionalSampleOffset + previousSample * (1.0-fractionalSampleOffset);
 
-	fractionalSampleOffset += samplesPerGet;
+	fractionalSampleOffset = fractionalSampleOffset + samplesPerGet;
 
 	// process volume
 	sample = sample * volume() / 127;
@@ -86,46 +84,35 @@ int EnhancedSamplesGenerator::getDuration(uint16_t frequency) {
 	// TODO this will produce an incorrect duration if the sample rate for the channel has been
 	// adjusted to differ from the underlying audio system sample rate
 	// At this point it's not clear how to resolve this, so we'll assume it hasn't been adjusted
-	return _sample.expired() ? 0 : (_sample.lock()->getSize() * 1000 / sampleRate()) / calculateSamplerate(frequency);
+	return !_sample ? 0 : (_sample->getSize() * 1000 / sampleRate()) / calculateSamplerate(frequency);
 }
 
 void EnhancedSamplesGenerator::seekTo(uint32_t position) {
-	if (!_sample.expired()) {
-		auto samplePtr = _sample.lock();
-		samplePtr->seekTo(position, index, blockIndex, repeatCount);
+	_sample->seekTo(position, index, blockIndex, repeatCount);
 
-		// prepare our fractional sample data for playback
-		fractionalSampleOffset = 0.0;
-		previousSample = samplePtr->getSample(index, blockIndex);
-		currentSample = samplePtr->getSample(index, blockIndex);
-	}
+	// prepare our fractional sample data for playback
+	fractionalSampleOffset = 0.0;
+	previousSample = _sample->getSample(index, blockIndex);
+	currentSample = _sample->getSample(index, blockIndex);
 }
 
 double EnhancedSamplesGenerator::calculateSamplerate(uint16_t frequency) {
-	if (!_sample.expired()) {
-		auto samplePtr = _sample.lock();
-		auto baseFrequency = samplePtr->baseFrequency;
-		auto frequencyAdjust = baseFrequency > 0 ? (double)frequency / (double)baseFrequency : 1.0;
-		return frequencyAdjust * ((double)samplePtr->sampleRate / (double)(sampleRate()));
-	}
-	return 1.0;
+	auto baseFrequency = _sample->baseFrequency;
+	auto frequencyAdjust = baseFrequency > 0 ? (double)frequency / (double)baseFrequency : 1.0;
+	return frequencyAdjust * ((double)_sample->sampleRate / (double)(sampleRate()));
 }
 
 int8_t EnhancedSamplesGenerator::getNextSample() {
-	if (!_sample.expired()) {
-		auto samplePtr = _sample.lock();
-		auto sample = samplePtr->getSample(index, blockIndex);
-		
-		// looping magic
-		repeatCount--;
-		if (repeatCount == 0) {
-			// we've reached the end of the repeat section, so loop back
-			seekTo(samplePtr->repeatStart);
-		}
-
-		return sample;
+	auto sample = _sample->getSample(index, blockIndex);
+	
+	// looping magic
+	repeatCount--;
+	if (repeatCount == 0) {
+		// we've reached the end of the repeat section, so loop back
+		seekTo(_sample->repeatStart);
 	}
-	return 0;
+
+	return sample;
 }
 
 #endif // ENHANCED_SAMPLES_GENERATOR_H

--- a/video/enhanced_samples_generator.h
+++ b/video/enhanced_samples_generator.h
@@ -46,7 +46,9 @@ void EnhancedSamplesGenerator::setFrequency(int frequency) {
 			previousSample = samplePtr->getSample();
 			currentSample = samplePtr->getSample();
 		} else {
-			samplesPerGet = ((double)frequency / (double)samplePtr->baseFrequency) * ((double)samplePtr->sampleRate / (double)(AUDIO_DEFAULT_SAMPLE_RATE));
+			auto baseFrequency = samplePtr->baseFrequency;
+			auto frequencyAdjust = baseFrequency > 0 ? (double)frequency / (double)baseFrequency : 1.0;
+			samplesPerGet = frequencyAdjust * ((double)samplePtr->sampleRate / (double)(AUDIO_DEFAULT_SAMPLE_RATE));
 		}
 	}
 }
@@ -58,6 +60,7 @@ int EnhancedSamplesGenerator::getSample() {
 
 	auto samplePtr = _sample.lock();
 
+	// if we've moved far enough along, read the next sample
 	while (fractionalSampleOffset >= 1.0) {
 		previousSample = currentSample;
 		currentSample = samplePtr->getSample();

--- a/video/envelopes/frequency.h
+++ b/video/envelopes/frequency.h
@@ -50,8 +50,8 @@ SteppedFrequencyEnvelope::SteppedFrequencyEnvelope(std::shared_ptr<std::vector<F
 		_totalAdjustment += (phase.number * phase.adjustment);
 	}
 
-	debug_log("audio_driver: SteppedFrequencyEnvelope: totalSteps=%d, totalAdjustment=%d\n\r", this->_totalSteps, this->_totalAdjustment);
-	debug_log("audio_driver: SteppedFrequencyEnvelope: stepLength=%d, repeats=%d, restricts=%d, totalLength=%d\n\r", this->_stepLength, this->_repeats, this->_restrict, _totalLength);
+	debug_log("audioDriver: SteppedFrequencyEnvelope: totalSteps=%d, totalAdjustment=%d\n\r", this->_totalSteps, this->_totalAdjustment);
+	debug_log("audioDriver: SteppedFrequencyEnvelope: stepLength=%d, repeats=%d, restricts=%d, totalLength=%d\n\r", this->_stepLength, this->_repeats, this->_restrict, _totalLength);
 }
 
 uint16_t SteppedFrequencyEnvelope::getFrequency(uint16_t baseFrequency, uint32_t elapsed, int32_t duration) {

--- a/video/envelopes/volume.h
+++ b/video/envelopes/volume.h
@@ -36,7 +36,7 @@ ADSRVolumeEnvelope::ADSRVolumeEnvelope(uint16_t attack, uint16_t decay, uint8_t 
 {
 	// attack, decay, release are time values in milliseconds
 	// sustain is 0-255, centered on 127, and is the relative sustain level
-	debug_log("audio_driver: ADSRVolumeEnvelope: attack=%d, decay=%d, sustain=%d, release=%d\n\r", this->_attack, this->_decay, this->_sustain, this->_release);
+	debug_log("audioDriver: ADSRVolumeEnvelope: attack=%d, decay=%d, sustain=%d, release=%d\n\r", this->_attack, this->_decay, this->_sustain, this->_release);
 }
 
 uint8_t ADSRVolumeEnvelope::getVolume(uint8_t baseVolume, uint32_t elapsed, int32_t duration) {

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -33,7 +33,7 @@ void VDUStreamProcessor::vdu(uint8_t c) {
 			setActiveViewport(VIEWPORT_GRAPHICS);
 			break;
 		case 0x07:	// Bell
-			play_note(0, 100, 750, 125);
+			playNote(0, 100, 750, 125);
 			break;
 		case 0x08:  // Cursor Left
 			cursorLeft();

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -199,6 +199,14 @@ void VDUStreamProcessor::vdu_sys_audio() {
 				audioChannels[channel]->seekTo(position);
 			}
 		}	break;
+
+		case AUDIO_CMD_DURATION: {
+			auto duration = read24_t();		if (duration == -1) return;
+
+			if (channelEnabled(channel)) {
+				audioChannels[channel]->setDuration(duration);
+			}
+		}
 	}
 }
 
@@ -278,9 +286,9 @@ void VDUStreamProcessor::setFrequencyEnvelope(uint8_t channel, uint8_t type) {
 				debug_log("vdu_sys_audio: channel %d - frequency envelope disabled\n\r", channel);
 				break;
 			case AUDIO_FREQUENCY_ENVELOPE_STEPPED:
-				auto phaseCount = readByte_t();	if (phaseCount == -1) return;
+				auto phaseCount = readByte_t();		if (phaseCount == -1) return;
 				auto control = readByte_t();		if (control == -1) return;
-				auto stepLength = readWord_t();	if (stepLength == -1) return;
+				auto stepLength = readWord_t();		if (stepLength == -1) return;
 				auto phases = make_shared_psram<std::vector<FrequencyStepPhase>>();
 				for (auto n = 0; n < phaseCount; n++) {
 					auto adjustment = readWord_t();	if (adjustment == -1) return;

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -185,6 +185,9 @@ uint8_t VDUStreamProcessor::createSampleFromBuffer(uint16_t bufferId, uint8_t fo
 		make_shared_psram<AudioSample>(buffers[bufferId], format & AUDIO_FORMAT_DATA_MASK, sampleRate)
 		: make_shared_psram<AudioSample>(buffers[bufferId], format);
 	if (sample) {
+		if (format & AUDIO_FORMAT_TUNEABLE) {
+			sample->baseFrequency = AUDIO_DEFAULT_FREQUENCY;
+		}
 		samples[bufferId] = sample;
 		return 1;
 	}

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -93,6 +93,19 @@ void VDUStreamProcessor::vdu_sys_audio() {
 					sendAudioStatus(channel, createSampleFromBuffer(bufferId, format, sampleRate));
 				}	break;
 
+				case AUDIO_SAMPLE_SET_FREQUENCY: {
+					auto frequency = readWord_t();	if (frequency == -1) return;
+
+					sendAudioStatus(channel, setSampleFrequency(sampleNum, frequency));
+				}	break;
+
+				case AUDIO_SAMPLE_BUFFER_SET_FREQUENCY: {
+					auto bufferId = readWord_t();	if (bufferId == -1) return;
+					auto frequency = readWord_t();	if (frequency == -1) return;
+
+					sendAudioStatus(channel, setSampleFrequency(bufferId, frequency));
+				}	break;
+
 				case AUDIO_SAMPLE_DEBUG_INFO: {
 					debug_log("Sample info: %d (%d)\n\r", (int8_t)channel, sampleNum);
 					debug_log("  samples count: %d\n\r", samples.size());
@@ -242,6 +255,17 @@ void VDUStreamProcessor::setFrequencyEnvelope(uint8_t channel, uint8_t type) {
 				break;
 		}
 	}
+}
+
+// Set sample frequency
+//
+uint8_t VDUStreamProcessor::setSampleFrequency(uint16_t sampleId, uint16_t frequency) {
+	if (samples.find(sampleId) == samples.end()) {
+		debug_log("vdu_sys_audio: sample %d not found\n\r", sampleId);
+		return 0;
+	}
+	samples[sampleId]->baseFrequency = frequency;
+	return 1;
 }
 
 #endif // VDU_AUDIO_H

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -137,7 +137,7 @@ void VDUStreamProcessor::vdu_sys_audio() {
 					debug_log("  samples count: %d\n\r", samples.size());
 					debug_log("  free mem: %d\n\r", heap_caps_get_free_size(MALLOC_CAP_8BIT));
 					auto sample = samples[sampleNum];
-					if (sample == nullptr) {
+					if (!sample) {
 						debug_log("  sample is null\n\r");
 						break;
 					}
@@ -254,8 +254,8 @@ uint8_t VDUStreamProcessor::createSampleFromBuffer(uint16_t bufferId, uint8_t fo
 	}
 	clearSample(bufferId);
 	auto sample = (format & AUDIO_FORMAT_WITH_RATE) ?
-		make_shared_psram<AudioSample>(buffers[bufferId], format & AUDIO_FORMAT_DATA_MASK, sampleRate)
-		: make_shared_psram<AudioSample>(buffers[bufferId], format & AUDIO_FORMAT_DATA_MASK);
+		std::make_shared<AudioSample>(buffers[bufferId], format & AUDIO_FORMAT_DATA_MASK, sampleRate)
+		: std::make_shared<AudioSample>(buffers[bufferId], format & AUDIO_FORMAT_DATA_MASK);
 	if (sample) {
 		if (format & AUDIO_FORMAT_TUNEABLE) {
 			sample->baseFrequency = AUDIO_DEFAULT_FREQUENCY;

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -345,6 +345,9 @@ uint8_t VDUStreamProcessor::setSampleRepeatLength(uint16_t sampleId, uint32_t re
 		debug_log("vdu_sys_audio: sample %d not found\n\r", sampleId);
 		return 0;
 	}
+	if (repeatLength == 0xFFFFFF) {
+		repeatLength = -1;
+	}
 	samples[sampleId]->repeatLength = repeatLength;
 	return 1;
 }

--- a/video/vdu_audio.h
+++ b/video/vdu_audio.h
@@ -206,7 +206,18 @@ void VDUStreamProcessor::vdu_sys_audio() {
 			if (channelEnabled(channel)) {
 				audioChannels[channel]->setDuration(duration);
 			}
-		}
+		} break;
+
+		case AUDIO_CMD_SAMPLERATE: {
+			auto sampleRate = readWord_t();	if (sampleRate == -1) return;
+
+			if (channel == 255) {
+				// set underlying sample rate
+				setSampleRate(sampleRate);
+			} else if (channelEnabled(channel)) {
+				audioChannels[channel]->setSampleRate(sampleRate);
+			}
+		}	break;
 	}
 }
 

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -244,7 +244,10 @@ void VDUStreamProcessor::bufferCall(uint16_t callBufferId, uint32_t offset) {
 void VDUStreamProcessor::bufferClear(uint16_t bufferId) {
 	debug_log("bufferClear: buffer %d\n\r", bufferId);
 	if (bufferId == 65535) {
-		buffers.clear();
+		// iterate thru our buffers and clear their vectors
+		for (auto bufferPair : buffers) {
+			bufferPair.second.clear();
+		}
 		resetBitmaps();
 		resetSamples();
 		return;
@@ -253,7 +256,7 @@ void VDUStreamProcessor::bufferClear(uint16_t bufferId) {
 		debug_log("bufferClear: buffer %d not found\n\r", bufferId);
 		return;
 	}
-	buffers.erase(bufferId);
+	buffers[bufferId].clear();
 	clearBitmap(bufferId);
 	clearSample(bufferId);
 	debug_log("bufferClear: cleared buffer %d\n\r", bufferId);
@@ -732,7 +735,7 @@ void VDUStreamProcessor::bufferConsolidate(uint16_t bufferId) {
 void clearTargets(std::vector<uint16_t> targets) {
 	for (auto target : targets) {
 		if (buffers.find(target) != buffers.end()) {
-			buffers.erase(target);
+			buffers[target].clear();
 		}
 		clearBitmap(target);
 	}

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -56,6 +56,7 @@ class VDUStreamProcessor {
 		uint8_t createSampleFromBuffer(uint16_t bufferId, uint8_t format, uint16_t sampleRate);
 		void setVolumeEnvelope(uint8_t channel, uint8_t type);
 		void setFrequencyEnvelope(uint8_t channel, uint8_t type);
+		uint8_t setSampleFrequency(uint16_t bufferId, uint16_t frequency);
 
 		void vdu_sys_sprites(void);
 		void receiveBitmap(uint8_t cmd, uint16_t width, uint16_t height);

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -53,7 +53,7 @@ class VDUStreamProcessor {
 		void vdu_sys_audio();
 		void sendAudioStatus(uint8_t channel, uint8_t status);
 		uint8_t loadSample(uint16_t bufferId, uint32_t length);
-		uint8_t createSampleFromBuffer(uint16_t bufferId, uint8_t format);
+		uint8_t createSampleFromBuffer(uint16_t bufferId, uint8_t format, uint16_t sampleRate);
 		void setVolumeEnvelope(uint8_t channel, uint8_t type);
 		void setFrequencyEnvelope(uint8_t channel, uint8_t type);
 

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -57,6 +57,8 @@ class VDUStreamProcessor {
 		void setVolumeEnvelope(uint8_t channel, uint8_t type);
 		void setFrequencyEnvelope(uint8_t channel, uint8_t type);
 		uint8_t setSampleFrequency(uint16_t bufferId, uint16_t frequency);
+		uint8_t setSampleRepeatStart(uint16_t bufferId, uint32_t offset);
+		uint8_t setSampleRepeatLength(uint16_t bufferId, uint32_t length);
 
 		void vdu_sys_sprites(void);
 		void receiveBitmap(uint8_t cmd, uint16_t width, uint16_t height);

--- a/video/video.ino
+++ b/video/video.ino
@@ -30,7 +30,7 @@
 // 29/03/2023:					+ Typo in boot screen fixed
 // 01/04/2023:					+ Added resetPalette to MODE, timeouts to VDU commands
 // 08/04/2023:				RC4 + Removed delay in readbyte_t, fixed VDP_SCRCHAR, VDP_SCRPIXEL
-// 12/04/2023:					+ Fixed bug in play_note
+// 12/04/2023:					+ Fixed bug in playNote
 // 13/04/2023:					+ Fixed bootup fail with no keyboard
 // 17/04/2023:				RC5 + Moved wait_completion in vdu so that it only executes after graphical operations
 // 18/04/2023:					+ Minor tweaks to wait completion logic
@@ -84,7 +84,7 @@ void setup() {
 	processor = new VDUStreamProcessor(&VDPSerial);
 	processor->wait_eZ80();
 	setupKeyboardAndMouse();
-	init_audio();
+	initAudio();
 	copy_font();
 	set_mode(1);
 	processor->sendModeInformation();


### PR DESCRIPTION
This builds on work done by @movievertigo in #143 

With this PR it becomes possible to set a "base frequency" on a sample, and once that is set the sample can be played at different frequencies.

It also becomes possible to adjust the sample rate of the underlying audio system.  This allows the audio system to run with a higher fidelity than the default 16khz - altho that remains the default.

Individual samples can also be set to differing sample rates.  The audio system will automatically compensate for this, ensuring that samples play back at the correct speed irrespective of what the rate the sample has been set to or the underlying audio system.

Looping of samples can now also be controlled; it is possible to set the byte offset within a sample of where repeats start from as well as the length of the section to repeat.

Note duration can be changed after starting playback, or set to initiate playback.  This allows for durations longer than 65s, which can be useful when playing back long samples.

documentation on the audio system API changes to support this enhanced functionality can be found in AgonConsole8/agon-docs#6
