### PR TITLE
Add ability to terminate or suspend terminal mode

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -239,6 +239,18 @@
 //
 void debug_log(const char *format, ...);
 
+// Terminal states
+//
+enum TerminalState {
+	Disabled,
+	Disabling,
+	Enabling,
+	Enabled,
+	Suspending,
+	Suspended,
+	Resuming
+};
+
 // Additional modelines
 //
 #ifndef VGA_640x240_60Hz

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -15,7 +15,7 @@
 #include "vdu_sprites.h"
 #include "updater.h"
 
-extern void switchTerminalMode(bool enable);	// Switch to terminal mode
+extern void startTerminal();					// Start the terminal
 extern void setConsoleMode(bool mode);			// Set console mode
 
 bool			initialised = false;			// Is the system initialised yet?
@@ -173,7 +173,7 @@ void VDUStreamProcessor::vdu_sys_video() {
 			setConsoleMode((bool) b);
 		}	break;
 		case VDP_TERMINALMODE: {		// VDU 23, 0, &FF
-			switchTerminalMode(true); 	// Switch to terminal mode
+			startTerminal();		 	// Switch to, or resume, terminal mode
 		}	break;
   	}
 }

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -15,7 +15,7 @@
 #include "vdu_sprites.h"
 #include "updater.h"
 
-extern void switchTerminalMode();				// Switch to terminal mode
+extern void switchTerminalMode(bool enable);	// Switch to terminal mode
 extern void setConsoleMode(bool mode);			// Set console mode
 
 bool			initialised = false;			// Is the system initialised yet?
@@ -173,7 +173,7 @@ void VDUStreamProcessor::vdu_sys_video() {
 			setConsoleMode((bool) b);
 		}	break;
 		case VDP_TERMINALMODE: {		// VDU 23, 0, &FF
-			switchTerminalMode(); 		// Switch to terminal mode
+			switchTerminalMode(true); 	// Switch to terminal mode
 		}	break;
   	}
 }

--- a/video/video.ino
+++ b/video/video.ino
@@ -58,11 +58,11 @@
 
 HardwareSerial	DBGSerial(0);
 
-bool			terminalMode = false;			// Terminal mode (for CP/M)
-bool			exitTerminal = false;			// Flag to indicate terminal mode should be exited
+#include "agon.h"								// Configuration file
+
+TerminalState	terminalState = TerminalState::Disabled;		// Terminal state (for CP/M, etc)
 bool			consoleMode = false;			// Serial console mode (0 = off, 1 = console enabled)
 
-#include "agon.h"								// Configuration file
 #include "agon_ps2.h"							// Keyboard support
 #include "agon_audio.h"							// Audio support
 #include "agon_ttxt.h"
@@ -100,12 +100,7 @@ void loop() {
 	bool cursorState = false;
 
 	while (true) {
-		if (terminalMode) {
-			if (exitTerminal) {
-				switchTerminalMode(false);
-				continue;
-			}
-			do_keyboard_terminal();
+		if (processTerminal()) {
 			continue;
 		}
 		cursorVisible = ((count & 0xFFFF) == 0);
@@ -163,12 +158,6 @@ void do_keyboard_terminal() {
 		// send raw byte straight to z80
 		processor->writeByte(ascii);
 	}
-
-	// Write anything read from z80 to the screen
-	//
-	while (processor->byteAvailable()) {
-		Terminal->write(processor->readByte());
-	}
 }
 
 // Handle the mouse
@@ -221,45 +210,126 @@ void setConsoleMode(bool mode) {
 	consoleMode = mode;
 }
 
-// Switch to terminal mode
+// Terminal mode state machine transition calls
 //
-void switchTerminalMode(bool enable) {
-	if (terminalMode == enable) {
-		return;
+void startTerminal() {
+	switch (terminalState) {
+		case TerminalState::Disabled: {
+			terminalState = TerminalState::Enabling;
+		} break;
+		case TerminalState::Suspending: {
+			terminalState = TerminalState::Enabled;
+		} break;
+		case TerminalState::Suspended: {
+			terminalState = TerminalState::Resuming;
+		} break;
 	}
-	exitTerminal = false;
-	cls(true);
-	canvas.reset();
-	if (enable) {
-		Terminal = std::unique_ptr<fabgl::Terminal>(new fabgl::Terminal());
-		Terminal->begin(_VGAController.get());	
-		Terminal->connectSerialPort(VDPSerial);
-		Terminal->enableCursor(true);
-		// onVirtualKey is triggered whenever a key is pressed or released
-		Terminal->onVirtualKeyItem = [&](VirtualKeyItem * vkItem) {
-			if (vkItem->vk == VirtualKey::VK_F12) {
-				if (vkItem->CTRL && (vkItem->LALT || vkItem->RALT)) {
-					// CTRL + ALT + F12: emergency exit terminal mode
-					exitTerminal = true;
-				}
-			}
-		};
+}
 
-		// onUserSequence is triggered whenever a User Sequence has been received (ESC + '_#' ... '$'), where '...' is sent here
-		Terminal->onUserSequence = [&](char const * seq) {
-			// 'Q!': exit terminal mode
-			if (strcmp("Q!", seq) == 0) {
-				exitTerminal = true;
-			}
-		};
-	} else {
-		Terminal->deactivate();
-		Terminal = nullptr;
-		set_mode(1);
-		processor->sendModeInformation();
+void stopTerminal() {
+	switch (terminalState) {
+		case TerminalState::Enabled:
+		case TerminalState::Resuming: 
+		case TerminalState::Suspended:
+		case TerminalState::Suspending: {
+			terminalState = TerminalState::Disabling;
+		} break;
+		case TerminalState::Enabling: {
+			terminalState = TerminalState::Disabled;
+		} break;
 	}
-	terminalMode = enable;
-	debug_log("Terminal mode %s\n\r", terminalMode ? "enabled" : "disabled");
+}
+
+void suspendTerminal() {
+	switch (terminalState) {
+		case TerminalState::Enabled:
+		case TerminalState::Resuming: {
+			terminalState = TerminalState::Suspending;
+			processTerminal();
+		} break;
+		case TerminalState::Enabling: {
+			// Finish enabling, then suspend
+			processTerminal();
+			terminalState = TerminalState::Suspending;
+		} break;
+	}
+}
+
+// Process terminal state machine
+//
+bool processTerminal() {
+	switch (terminalState) {
+		case TerminalState::Disabled: {
+			// Terminal is not currently active, so pass on to VDU system
+			return false;
+		} break;
+		case TerminalState::Suspended: {
+			// Terminal temporarily deactivated, so pass on to VDU system
+			// but keep processing keyboard input
+			do_keyboard_terminal();
+			return false;
+		} break;
+		case TerminalState::Enabling: {
+			// Turn on the terminal
+			Terminal = std::unique_ptr<fabgl::Terminal>(new fabgl::Terminal());
+			Terminal->begin(_VGAController.get());	
+			Terminal->connectSerialPort(VDPSerial);
+			Terminal->enableCursor(true);
+			// onVirtualKey is triggered whenever a key is pressed or released
+			Terminal->onVirtualKeyItem = [&](VirtualKeyItem * vkItem) {
+				if (vkItem->vk == VirtualKey::VK_F12) {
+					if (vkItem->CTRL && (vkItem->LALT || vkItem->RALT)) {
+						// CTRL + ALT + F12: emergency exit terminal mode
+						stopTerminal();
+					}
+				}
+			};
+
+			// onUserSequence is triggered whenever a User Sequence has been received (ESC + '_#' ... '$'), where '...' is sent here
+			Terminal->onUserSequence = [&](char const * seq) {
+				// 'Q!': exit terminal mode
+				if (strcmp("Q!", seq) == 0) {
+					stopTerminal();
+				}
+				if (strcmp("S!", seq) == 0) {
+					suspendTerminal();
+				}
+			};
+			debug_log("Terminal enabled\n\r");
+			terminalState = TerminalState::Enabled;
+		} break;
+		case TerminalState::Enabled: {
+			do_keyboard_terminal();
+			// Write anything read from z80 to the screen
+			// but do this a byte at a time, as VDU commands after a "suspend" will get lost
+			if (processor->byteAvailable()) {
+				Terminal->write(processor->readByte());
+			}
+		} break;
+		case TerminalState::Disabling: {
+			Terminal->deactivate();
+			Terminal = nullptr;
+			set_mode(1);
+			processor->sendModeInformation();
+			debug_log("Terminal disabled\n\r");
+			terminalState = TerminalState::Disabled;
+		} break;
+		case TerminalState::Suspending: {
+			// No need to deactivate terminal here... we just stop sending it serial data
+			debug_log("Terminal suspended\n\r");
+			terminalState = TerminalState::Suspended;
+		} break;
+		case TerminalState::Resuming: {
+			// As we're not deactivating the terminal, we don't need to re-activate it here
+			debug_log("Terminal resumed\n\r");
+			terminalState = TerminalState::Enabled;
+		} break;
+		default: {
+			debug_log("processTerminal: unknown terminal state %d\n\r", terminalState);
+			return false;
+		} break;
+	}
+	return true;
 }
 
 void print(char const * text) {


### PR DESCRIPTION
Adds the ability for terminal mode to recognise a specific escape sequence (ESC+`#_Q!$`) to exit terminal mode and restore regular VDP operation, allowing VDU handling to resume.  Exiting terminal mode changes to mode 1.

Also allows terminal mode to be suspended using a different escape sequence (ESC+`#_S!$`).  This allows programs running inside terminal mode to temporarily suspend terminal serial handling, allowing applications that use terminal mode to then send VDU commands.  Terminal mode is resumed using `VDU 23,0,&FF`, i.e. the same command sequence to start terminal mode.

When the terminal is suspended, keyboard handling is still sent terminal-style, rather than restoring to VDP protocol keyboard packets.  This should allow for programs to be written in CP/M to remain interactive whilst using VDU commands for output.

This code also adds an "emergency exit" key combo to quit out of terminal mode of Ctrl+Alt+F12