### PR TITLE
add support for copy-screen-to-bitmap

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ board_build.f_cpu = 240000000L
 board_build.f_flash = 80000000L
 framework = arduino
 lib_deps =
-    https://github.com/avalonbits/vdp-gl.git#1.0.3
+    https://github.com/AgonConsole8/vdp-gl.git#copy-to-bitmap
     fbiego/ESP32Time@^2.0.0
 build_flags =
     -DBOARD_HAS_PSRAM

--- a/video/vdu_buffered.h
+++ b/video/vdu_buffered.h
@@ -263,7 +263,7 @@ void VDUStreamProcessor::bufferClear(uint16_t bufferId) {
 // This is used for creating buffers to redirect output to
 //
 std::shared_ptr<WritableBufferStream> VDUStreamProcessor::bufferCreate(uint16_t bufferId, uint32_t size) {
-	if (bufferId == 0 || bufferId == 65535) {
+	if (bufferId == 65535) {
 		debug_log("bufferCreate: bufferId %d is reserved\n\r", bufferId);
 		return nullptr;
 	}

--- a/video/vdu_sprites.h
+++ b/video/vdu_sprites.h
@@ -236,6 +236,10 @@ void VDUStreamProcessor::createBitmapFromScreen(uint16_t bufferId) {
 
 	// create a new buffer of appropriate size, and set as a native format bitmap
 	auto buffer = bufferCreate(bufferId, size);
+	if (!buffer) {
+		debug_log("vdu_sys_sprites: failed to create buffer\n\r");
+		return;
+	}
 	createBitmapFromBuffer(bufferId, 3, width, height);
 	// Copy screen area to buffer
 	canvas->copyToBitmap(x1, y1, getBitmap(bufferId).get());

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -57,8 +57,10 @@ class VDUStreamProcessor {
 		void setVolumeEnvelope(uint8_t channel, uint8_t type);
 		void setFrequencyEnvelope(uint8_t channel, uint8_t type);
 
-		void vdu_sys_sprites(void);
-		void receiveBitmap(uint8_t cmd, uint16_t width, uint16_t height);
+		void vdu_sys_sprites();
+		void receiveBitmap(uint16_t bufferId, uint16_t width, uint16_t height);
+		void createBitmapFromScreen(uint16_t bufferId);
+		void createEmptyBitmap(uint16_t bufferId, uint16_t width, uint16_t height, uint32_t color);
 		void createBitmapFromBuffer(uint16_t bufferId, uint8_t format, uint16_t width, uint16_t height);
 
 		void vdu_sys_hexload(void);


### PR DESCRIPTION
adds support for Acorn GXR style “copy screen to bitmap” command sequence

this is supported on both `VDU 23,27,1,n,0,0,0` to define bitmap `n` from the last two graphics cursor positions, using an 8-bit bitmap ID and also `VDU 23,27,&21,n;0;` using a 16-bit bitmap/buffer ID

these commands are compatible with the existing `VDU 23,27,1` and `VDU 23,27,&21` commands - the system can tell the difference as these variants require a zero “height” value

if the buffer specified already exists then it will be deleted/cleared before the new bitmap is created from the screen.  the resultant bitmap data will be in vdp-gl’s `Bitmap::Native` format

the original Acorn command documentation specifies that a few more zeros should be sent.  you can safely send additional zeros, as per Acorn’s documentation, as they will just be ignored.

it should be noted that `VDU 23,27,&21` when pointing to an existing buffer to set it to be a bitmap also usually expects a `format` byte, but this isn’t required/supported/needed for copying screen to bitmap, i.e. this command variant requires one less byte to be sent

requires an updated/custom vdp-gl, and can thus currently only be built using PlatformIO