### PR TITLE
read colours

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -45,6 +45,7 @@
 #define VDP_RTC					0x87	// RTC
 #define VDP_KEYSTATE			0x88	// Keyboard repeat rate and LED status
 #define VDP_MOUSE				0x89	// Mouse data
+#define VDP_READ_COLOUR			0x94	// Read colour
 #define VDP_BUFFERED			0xA0	// Buffered commands
 #define VDP_UPDATER				0xA1	// Update VDP
 #define VDP_LOGICALCOORDS		0xC0	// Switch BBC Micro style logical coords on and off

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -41,6 +41,7 @@ class VDUStreamProcessor {
 		void sendCursorPosition();
 		void sendScreenChar(uint16_t x, uint16_t y);
 		void sendScreenPixel(uint16_t x, uint16_t y);
+		void sendColour(uint8_t colour);
 		void sendTime();
 		void vdu_sys_video_time();
 		void sendKeyboardState();


### PR DESCRIPTION
reads colours, either from the palette, or one of the active colours

this is done using `VDU 23, 0, &94, colour`.  values will be returned using the `PACKET_SCRPIXEL` response packet, and therefore MOS will interpret these exactly the same as reading a screen pixel via `VDU 23, 0, &84`. values will therefore be exposed in MOS in the exact same `scrpixel` and `scrpixelIndex` sysvar bytes

when using this command, colours 0-63 will be interpreted as palette colours, 128 will return the currently selected text foreground colour, 129 the text  background colour, 130 graphics foreground, and 131 graphics background.  any other colour values will be ignored

addresses #145 