### PR TITLE
Fix buffer reverse command so 16-bit chunk sizes work

### DIFF
--- a/video/buffers.h
+++ b/video/buffers.h
@@ -25,7 +25,7 @@ int32_t resolveBufferId(int32_t bufferId, uint16_t currentId) {
 }
 
 // Reverse values in a buffer
-void reverseValues(uint8_t * data, uint32_t length, uint8_t valueSize) {
+void reverseValues(uint8_t * data, uint32_t length, uint16_t valueSize) {
 	// get last offset into buffer
 	auto bufferEnd = length - valueSize;
 


### PR DESCRIPTION
Bug fix care of @movievertigo who spotted that the buffer reverse command wasn't properly handling size values over 8-bits, caused by the underlying `reverseValues` function argument not being 16-bits like it should have been